### PR TITLE
Asyncify grafana handler to improve performance

### DIFF
--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/platform-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "@fbcnms/auth": "^0.1.0",
     "@fbcnms/babel-register": "^0.1.0",


### PR DESCRIPTION
Summary: Loading the grafana page can take a few seconds which feels laggy. This diff takes the function `syncTenants` and makes it run async with the other syncing functions since the result of this is independent of all the others. It also happens to be the longest and in testing it cut the load time in about half.

Differential Revision: D22736306

