### PR TITLE
fbcnms/auth: bump package version

### DIFF
--- a/fbcnms-packages/fbcnms-auth/package.json
+++ b/fbcnms-packages/fbcnms-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/auth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "@fbcnms/webpack-config": "^0.1.0",
     "email-validator": "^2.0.4",


### PR DESCRIPTION
v0.1.0 was released manaully by me - this one should publish the latest changes to npm