### PR TITLE
Remove relay/graphql from shared packages

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -36,7 +36,6 @@ module.exports = {
   ],
   plugins: [
     'babel-plugin-lodash',
-    'babel-plugin-relay',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-nullish-coalescing-operator',
     '@babel/plugin-proposal-optional-chaining',

--- a/fbcnms-packages/eslint-config-fbcnms/README.md
+++ b/fbcnms-packages/eslint-config-fbcnms/README.md
@@ -4,18 +4,18 @@ This package provides Facebook NMS' eslint config as an extensible shared config
 
 ## Usage
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-relay`, `eslint-plugin-header`, `eslint-plugin-import`, `eslint-plugin-node`, `eslint-plugin-lint`, `eslint-plugin-sort-imports-es6-autofix`, `eslint-config-fb-strict`.
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-header`, `eslint-plugin-import`, `eslint-plugin-node`, `eslint-plugin-lint`, `eslint-plugin-sort-imports-es6-autofix`, `eslint-config-fb-strict`.
 
 To install:
 
 Yarn
 ```
-yarn add eslint-config-fbcnms eslint-config-fb-strict eslint-plugin-relay eslint-plugin-header eslint-plugin-import eslint-plugin-node eslint-plugin-lint eslint-plugin-sort-imports-es6-autofix --dev
+yarn add eslint-config-fbcnms eslint-config-fb-strict eslint-plugin-header eslint-plugin-import eslint-plugin-node eslint-plugin-lint eslint-plugin-sort-imports-es6-autofix --dev
 ```
 
 npm
 ```
-npm install --save-dev eslint-config-fbcnms eslint-config-fb-strict eslint-plugin-relay eslint-plugin-header eslint-plugin-import eslint-plugin-node eslint-plugin-lint eslint-plugin-sort-imports-es6-autofix
+npm install --save-dev eslint-config-fbcnms eslint-config-fb-strict eslint-plugin-header eslint-plugin-import eslint-plugin-node eslint-plugin-lint eslint-plugin-sort-imports-es6-autofix
 ```
 
 - Add "extends": "eslint-config-fbcnms" to your .eslintrc

--- a/fbcnms-packages/eslint-config-fbcnms/index.js
+++ b/fbcnms-packages/eslint-config-fbcnms/index.js
@@ -27,29 +27,6 @@ const importStatement = String.raw`^(?:var|let|const|import type|import)\s+` +
 const maxLenIgnorePattern =
   '(?:' + importStatement + '|\\})' +
   String.raw`\s*(?:=\s*require\(|from)[a-zA-Z_+./"'\s\d\-]+\)?[^;\n]*[;\n]`;
-const path = require('path');
-const {buildSchema, printSchema} = require('graphql');
-const fs = require('fs');
-
-const schemaPath1 = path.resolve(
-  __dirname,
-  '../../../../fbcode/fbc/symphony/graph/graphql/schema/symphony.graphql',
-);
-const schemaPath2 = path.resolve(
-    __dirname,
-    '../../../graph/graphql/schema/symphony.graphql',
-  )
-let schemaPath = '';
-if(fs.existsSync(schemaPath1)) {
-  schemaPath = schemaPath1;
-} else if (fs.existsSync(schemaPath2)) {
-  schemaPath = schemaPath2;
-}
-
-let schemaObject = {};
-if(schemaPath !== '') {
-  schemaObject = buildSchema(fs.readFileSync(schemaPath, {encoding: 'utf8'}));
-}
 
 const restrictedImportsRule = ['error',{
   'paths':[{
@@ -94,9 +71,7 @@ const eslintMap = {
     'prettier',
     'react',
     'react-hooks',
-    'relay',
     'sort-imports-es6-autofix',
-    'graphql',
   ],
   rules: {
     'comma-dangle': ['warn', 'always-multiline'],
@@ -183,9 +158,6 @@ const eslintMap = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
 
-    // Relay Plugin
-    'relay/unused-fields': 'off',
-
     // sort-imports autofix plugin (sort-imports doesnt autofix)
     'sort-imports-es6-autofix/sort-imports-es6': [2, {
       'ignoreCase': false,
@@ -231,19 +203,6 @@ const eslintMap = {
        'flowtype/no-weak-types': [0],
      },
    }],
-   'extends': [
-    'plugin:relay/recommended',
-  ],
 };
 
-if(Object.keys(schemaObject).length > 0) {
-  eslintMap['rules']['graphql/no-deprecated-fields'] = [
-      'error',
-      {
-        env: 'relay',
-        schemaString: printSchema(schemaObject),
-        tagName: 'graphql',
-      },
-  ]
-}
 module.exports = Object.assign({}, fbStrict, eslintMap);

--- a/fbcnms-packages/eslint-config-fbcnms/package.json
+++ b/fbcnms-packages/eslint-config-fbcnms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-fbcnms",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "This package provides Facebook NMS' eslint config as an extensible shared config. This is only used internally, use at your own risk",
   "repository": {
     "type": "git",
@@ -19,7 +19,6 @@
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-flowtype": "^4.3.0",
-    "eslint-plugin-graphql": "^3.1.1",
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-jest": "^22.7.1",
@@ -28,7 +27,6 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.14.2",
-    "eslint-plugin-relay": "^1.5.0",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0"
   },
   "publishConfig": {

--- a/fbcnms-packages/fbcnms-webpack-config/dev-webpack.js
+++ b/fbcnms-packages/fbcnms-webpack-config/dev-webpack.js
@@ -77,11 +77,12 @@ function createDevWebpackConfig(options: Options) {
               include: [
                 paths.appSrc,
                 paths.packagesDir,
+                paths.fbcnmsDir,
                 ...(options.extraPaths || []),
               ],
               loader: require.resolve('babel-loader'),
               options: {
-                configFile: '../../babel.config.js',
+                rootMode: 'upward',
                 // This is a feature of `babel-loader` for webpack (not Babel
                 // itself). It enables caching results in
                 // ./node_modules/.cache/babel-loader/ directory for faster

--- a/fbcnms-packages/fbcnms-webpack-config/dev-webpack.js
+++ b/fbcnms-packages/fbcnms-webpack-config/dev-webpack.js
@@ -30,7 +30,7 @@ function entry(value: any[], hot: boolean) {
 function createDevWebpackConfig(options: Options) {
   return {
     mode: 'development',
-    devtool: 'eval-cheap-module-source-map',
+    devtool: 'cheap-module-eval-source-map',
     entry: Object.assign(
       {
         main: entry([paths.appIndexJs], options.hot),

--- a/fbcnms-packages/fbcnms-webpack-config/package.json
+++ b/fbcnms-packages/fbcnms-webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/webpack-config",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-transform-react-jsx": "^7.0.0",

--- a/fbcnms-packages/fbcnms-webpack-config/paths.js
+++ b/fbcnms-packages/fbcnms-webpack-config/paths.js
@@ -24,5 +24,8 @@ module.exports = {
   appSrc: resolveApp('app'),
   distPath: resolveApp('static/dist'),
   packagesDir: resolveApp('../../fbcnms-packages'),
+  fbcnmsDir: path.dirname(
+    path.dirname(require.resolve('@fbcnms/babel-register')),
+  ),
   resolveApp,
 };

--- a/fbcnms-packages/fbcnms-webpack-config/production-webpack.js
+++ b/fbcnms-packages/fbcnms-webpack-config/production-webpack.js
@@ -62,11 +62,12 @@ function createProductionWebpackConfig(options: Options) {
               include: [
                 paths.appSrc,
                 paths.packagesDir,
+                paths.fbcnmsDir,
                 ...(options.extraPaths || []),
               ],
               loader: require.resolve('babel-loader'),
               options: {
-                configFile: '../../babel.config.js',
+                rootMode: 'upward',
                 // This is a feature of `babel-loader` for webpack (not Babel
                 // itself). It enables caching results in
                 // ./node_modules/.cache/babel-loader/ directory for faster

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "babel-plugin-fbt": "^0.10.4",
     "babel-plugin-fbt-runtime": "^0.9.9",
     "babel-plugin-lodash": "^3.3.4",
-    "babel-plugin-relay": "^8.0.0",
-    "eslint-plugin-graphql": "^3.1.1",
     "fbt": "^0.10.6"
   },
   "devDependencies": {
@@ -28,7 +26,7 @@
     "babel-jest": "^24.9.0",
     "eslint": "^6.0.1",
     "eslint-config-fb-strict": "^24.3.0",
-    "eslint-config-fbcnms": "^0.1.0",
+    "eslint-config-fbcnms": "^0.2.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-flowtype": "^4.3.0",
@@ -41,7 +39,6 @@
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^2.0.1",
-    "eslint-plugin-relay": "^1.5.0",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
     "flow-bin": "0.128.0",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5622,13 +5622,6 @@ babel-plugin-react-docgen@^4.1.0:
     react-docgen "^5.0.0"
     recast "^0.14.7"
 
-babel-plugin-relay@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-relay/-/babel-plugin-relay-8.0.0.tgz#4e412fe085c1aaf6a7d458a653f7a1d249cce067"
-  integrity sha512-modTJugk/BKmrZedRMq2B2Dx7JU/CbBlI0OY/fcs4pdt4rN5nimQEhwuuytltCYnUOHny5a/VemZwVReiH+sKg==
-  dependencies:
-    babel-plugin-macros "^2.0.0"
-
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -7256,14 +7249,6 @@ cross-domain-utils@^2.0.0, cross-domain-utils@^2.0.10:
   dependencies:
     zalgo-promise "^1.0.11"
 
-cross-fetch@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
-  integrity sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=
-  dependencies:
-    node-fetch "2.1.2"
-    whatwg-fetch "2.0.4"
-
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -8539,14 +8524,6 @@ eslint-plugin-flowtype@^4.3.0:
   dependencies:
     lodash "^4.17.15"
 
-eslint-plugin-graphql@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-3.1.1.tgz#640f7f73f12cee2f7145140bd2ff21694018bff5"
-  integrity sha512-VNu2AipS8P1BAnE/tcJ2EmBWjFlCnG+1jKdUlFNDQjocWZlFiPpMu9xYNXePoEXK+q+jG51M/6PdhOjEgJZEaQ==
-  dependencies:
-    graphql-config "^2.0.1"
-    lodash "^4.11.1"
-
 eslint-plugin-header@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz#0e048b5f0adfdd9754142d59d551ae6bfdaf90ad"
@@ -8657,13 +8634,6 @@ eslint-plugin-react@^7.14.2, eslint-plugin-react@^7.19.0:
     prop-types "^15.7.2"
     resolve "^1.17.0"
     string.prototype.matchall "^4.0.2"
-
-eslint-plugin-relay@^1.5.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-relay/-/eslint-plugin-relay-1.7.1.tgz#70f479becb06320e57dd86ebc0d38938cb8a5e6e"
-  integrity sha512-K7j5BF8raseLfgA97udZMGKEtWan+y5BLrBYlApy952saStF0ghYzU9WElIwoVIkcBO8QP+pT4AOuNFFNRzcUw==
-  dependencies:
-    graphql "^14.0.0 || ^15.0.0-rc.1"
 
 eslint-plugin-sort-imports-es6-autofix@^0.5.0:
   version "0.5.0"
@@ -10020,37 +9990,6 @@ grafana-dash-gen@^3.1.0:
     request-promise-native "^1.0.8"
     underscore "^1.9.2"
     xtend "^4.0.2"
-
-graphql-config@^2.0.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-2.2.2.tgz#a4b577826bba9b83e7b0f6cd617be43ca67da045"
-  integrity sha512-mtv1ejPyyR2mJUUZNhljggU+B/Xl8tJJWf+h145hB+1Y48acSghFalhNtXfPBcYl2tJzpb+lGxfj3O7OjaiMgw==
-  dependencies:
-    graphql-import "^0.7.1"
-    graphql-request "^1.5.0"
-    js-yaml "^3.10.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-
-graphql-import@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/graphql-import/-/graphql-import-0.7.1.tgz#4add8d91a5f752d764b0a4a7a461fcd93136f223"
-  integrity sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==
-  dependencies:
-    lodash "^4.17.4"
-    resolve-from "^4.0.0"
-
-graphql-request@^1.5.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
-  integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
-  dependencies:
-    cross-fetch "2.2.2"
-
-"graphql@^14.0.0 || ^15.0.0-rc.1":
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.1.0.tgz#b93e28de805294ec08e1630d901db550cb8960a1"
-  integrity sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q==
 
 graphql@^14.5.8:
   version "14.6.0"
@@ -12651,7 +12590,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.11:
+"lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.11:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -13553,11 +13492,6 @@ node-environment-flags@^1.0.5:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
-
-node-fetch@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -19245,11 +19179,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
-  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-fetch@>=0.10.0:
   version "3.1.0"


### PR DESCRIPTION
Summary:
Most applications dont use relay, just symphony.  So moving this
config to that particular projects, and out of lints/babel

Differential Revision: D22953774

