### PR TITLE
Improve CWF queries and labelling

### DIFF
--- a/fbcnms-packages/fbcnms-platform-server/grafana/dashboards/CWFDashboards.js
+++ b/fbcnms-packages/fbcnms-platform-server/grafana/dashboards/CWFDashboards.js
@@ -36,44 +36,49 @@ const SubscribersPanels: Array<PanelParams> = [
     title: 'Traffic In',
     targets: [
       {
-        expr: 'sum(octets_in{imsi=~"$imsi"})',
+        expr: 'sum(octets_in{imsi=~"$imsi"}) by (imsi)',
         legendFormat: '{{imsi}}',
       },
     ],
+    unit: 'decbytes',
   },
   {
     title: 'Traffic Out',
     targets: [
       {
-        expr: 'sum(octets_out{imsi=~"$imsi"})',
+        expr: 'sum(octets_out{imsi=~"$imsi"}) by (imsi)',
         legendFormat: '{{imsi}}',
       },
     ],
+    unit: 'decbytes',
   },
   {
     title: 'Throughput In',
     targets: [
       {
-        expr: 'avg(rate(octets_in{imsi=~"$imsi"}[5m]))',
+        expr: 'avg(rate(octets_in{imsi=~"$imsi"}[5m])) by (imsi)',
         legendFormat: '{{imsi}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Throughput Out',
     targets: [
       {
-        expr: 'avg(rate(octets_out{imsi=~"$imsi"}[5m]))',
+        expr: 'avg(rate(octets_out{imsi=~"$imsi"}[5m])) by (imsi)',
         legendFormat: '{{imsi}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Active Sessions',
     targets: [
       {
         expr: 'active_sessions{imsi=~"$imsi"}',
-        legendFormat: '{{imsi}}',
+        legendFormat:
+          '{{imsi}} Session: {{id}} -- Network: {{networkID}} -- Gateway: {{gatewayID}}',
       },
     ],
   },
@@ -84,7 +89,7 @@ const APNPanels: Array<PanelParams> = [
     title: 'Authorization',
     targets: [
       {
-        expr: 'sum(eap_auth{apn=~"$apn"}) by (code)',
+        expr: 'sum(eap_auth{apn=~"$apn"}) by (code, apn)',
         legendFormat: '{{apn}}-{{code}}',
       },
     ],
@@ -106,6 +111,7 @@ const APNPanels: Array<PanelParams> = [
         legendFormat: '{{apn}}',
       },
     ],
+    unit: 'decbytes',
   },
   {
     title: 'Traffic Out',
@@ -115,30 +121,33 @@ const APNPanels: Array<PanelParams> = [
         legendFormat: '{{apn}}',
       },
     ],
+    unit: 'decbytes',
   },
   {
     title: 'Throughput In',
     targets: [
       {
-        expr: 'avg(rate(octets_in{apn=~"$apn"}[5m]))',
+        expr: 'avg(rate(octets_in{apn=~"$apn"}[5m])) by (apn)',
         legendFormat: '{{apn}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Throughput Out',
     targets: [
       {
-        expr: 'avg(rate(octets_out{apn=~"$apn"}[5m]))',
+        expr: 'avg(rate(octets_out{apn=~"$apn"}[5m])) by (apn)',
         legendFormat: '{{apn}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Accounting Stops',
     targets: [
       {
-        expr: 'sum(accounting_stop{apn=~"$apn"})',
+        expr: 'sum(accounting_stop{apn=~"$apn"}) by (apn)',
         legendFormat: '{{apn}}',
       },
     ],
@@ -147,10 +156,11 @@ const APNPanels: Array<PanelParams> = [
     title: 'Session Terminate',
     targets: [
       {
-        expr: 'sum(session_terminate{apn=~"$apn"})',
+        expr: 'sum(session_terminate{apn=~"$apn"}) by (apn)',
         legendFormat: '{{apn}}',
       },
     ],
+    unit: 's',
   },
 ];
 
@@ -159,8 +169,8 @@ const NetworkPanels: Array<PanelParams> = [
     title: 'Authorization',
     targets: [
       {
-        expr: 'sum(eap_auth{networkID=~"$networkID"}) by (code)',
-        legendFormat: '{{networkID}}',
+        expr: 'sum(eap_auth{networkID=~"$networkID"}) by (code, networkID)',
+        legendFormat: '{{networkID}}-{{code}}',
       },
     ],
   },
@@ -168,7 +178,7 @@ const NetworkPanels: Array<PanelParams> = [
     title: 'Active Sessions',
     targets: [
       {
-        expr: 'sum(active_sessions{networkID=~"$apn"}) by (networkID)',
+        expr: 'sum(active_sessions{networkID=~"$networkID"}) by (networkID)',
         legendFormat: '{{networkID}}',
       },
     ],
@@ -181,33 +191,39 @@ const NetworkPanels: Array<PanelParams> = [
         legendFormat: '{{networkID}}',
       },
     ],
+    unit: 'decbytes',
   },
   {
     title: 'Traffic Out',
     targets: [
       {
-        expr: 'sum(octets_out{networkID=~"$apn"}) by (networkID)',
+        expr: 'sum(octets_out{networkID=~"$networkID"}) by (networkID)',
         legendFormat: '{{networkID}}',
       },
     ],
+    unit: 'decbytes',
   },
   {
     title: 'Throughput In',
     targets: [
       {
-        expr: 'avg(rate(octets_in{networkID=~"$networkID"}[5m]))',
+        expr:
+          'avg(rate(octets_in{networkID=~"$networkID"}[5m])) by (networkID)',
         legendFormat: '{{networkID}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Throughput Out',
     targets: [
       {
-        expr: 'avg(rate(octets_out{networkID=~"$networkID"}[5m]))',
+        expr:
+          'avg(rate(octets_out{networkID=~"$networkID"}[5m])) by (networkID)',
         legendFormat: '{{networkID}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Accounting Stops',
@@ -244,6 +260,7 @@ const NetworkPanels: Array<PanelParams> = [
         legendFormat: '{{networkID}}',
       },
     ],
+    unit: 's',
   },
 ];
 

--- a/fbcnms-packages/fbcnms-platform-server/grafana/dashboards/Dashboards.js
+++ b/fbcnms-packages/fbcnms-platform-server/grafana/dashboards/Dashboards.js
@@ -107,6 +107,7 @@ const NetworkPanels: Array<PanelParams> = [
         legendFormat: '{{networkID}}',
       },
     ],
+    unit: 's',
   },
   {
     title: 'Device Transmitting Status',
@@ -168,6 +169,7 @@ const GatewayPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Upload Throughput',
@@ -178,6 +180,7 @@ const GatewayPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}',
       },
     ],
+    unit: 'Bps',
   },
   {
     title: 'Latency',
@@ -188,6 +191,7 @@ const GatewayPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}',
       },
     ],
+    unit: 's',
   },
   {
     title: 'Gateway CPU %',
@@ -197,15 +201,17 @@ const GatewayPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}',
       },
     ],
+    unit: 'percent',
   },
   {
-    title: 'Temperature (℃)',
+    title: 'Temperature',
     targets: [
       {
         expr: 'temperature{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
         legendFormat: '{{gatewayID}} - {{sensor}}',
       },
     ],
+    unit: 'celsius',
   },
   {
     title: 'Disk %',
@@ -215,6 +221,7 @@ const GatewayPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}',
       },
     ],
+    unit: 'percent',
   },
   {
     title: 's6a Auth Failure',
@@ -248,6 +255,7 @@ const InternalPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}} - {{sensor}}',
       },
     ],
+    unit: 'percent',
   },
   {
     title: 'Virtual Memory Percent',
@@ -258,6 +266,7 @@ const InternalPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}',
       },
     ],
+    unit: 'percent',
   },
   {
     title: 'Backhaul Latency',
@@ -268,6 +277,7 @@ const InternalPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}',
       },
     ],
+    unit: 's',
   },
   {
     title: 'System Uptime',
@@ -278,6 +288,7 @@ const InternalPanels: Array<PanelParams> = [
         legendFormat: '{{gatewayID}}-{{service}}',
       },
     ],
+    unit: 's',
   },
   {
     title: 'Number of Service Restarts',
@@ -369,6 +380,7 @@ export function TemplateDashboard() {
 export type PanelParams = {
   title: string,
   targets: Array<{expr: string, legendFormat?: string}>,
+  unit?: string,
 };
 
 export function newPanel(params: PanelParams) {
@@ -380,6 +392,9 @@ export function newPanel(params: PanelParams) {
   // Have to add this after to avoid grafana-dash-gen from forcing the target
   // into a Graphite format
   pan.state.targets = params.targets;
+  if (params.unit) {
+    pan.state.y_formats[0] = params.unit;
+  }
   return pan;
 }
 

--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/platform-server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "dependencies": {
     "@fbcnms/auth": "^0.1.0",
     "@fbcnms/babel-register": "^0.1.0",


### PR DESCRIPTION
Summary: Some of the dashboards were not behaving as expected. Most of this was queries that performed aggregations not showing the relevant labels. This was because multiple aggregation results were returned which caused the label to not be shown. This diff fixes those and some other nits. Also added units to most dashboards.

Differential Revision: D22985171

