### PR TITLE
Add loading spinner till grafana loads

### DIFF
--- a/fbcnms-packages/fbcnms-ui/insights/Grafana.js
+++ b/fbcnms-packages/fbcnms-ui/insights/Grafana.js
@@ -9,7 +9,11 @@
  */
 
 import React from 'react';
+
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+
 import {makeStyles} from '@material-ui/styles';
+import {useState} from 'react';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -29,9 +33,17 @@ type Props = {
 
 export default function GrafanaDashboards(props: Props) {
   const classes = useStyles();
+  const [isLoading, setIsLoading] = useState(true);
   return (
-    <div className={classes.root}>
-      <iframe src={props.grafanaURL} className={classes.dashboardsIframe} />
-    </div>
+    <>
+      {isLoading ? <LoadingFiller /> : null}
+      <div className={classes.root}>
+        <iframe
+          src={props.grafanaURL}
+          onLoad={() => setIsLoading(false)}
+          className={classes.dashboardsIframe}
+        />
+      </div>
+    </>
   );
 }

--- a/fbcnms-packages/fbcnms-ui/package.json
+++ b/fbcnms-packages/fbcnms-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "dependencies": {
     "@material-ui/core": "^4.0.0",
     "@material-ui/icons": "^4.0.0",


### PR DESCRIPTION
In magma NMS,  Grafana is the default metric tab, we should add some sort of visual indication that we're loading the application. The initial queries take a little while and we don't want the user to think that the application has crashed.


New output
![grafana_gif](https://user-images.githubusercontent.com/8224854/91366802-97cd4680-e7b9-11ea-82f3-0d8e971946ce.gif)

