### PR TITLE
Mapbox.gl flow types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -46,20 +46,13 @@
 [untyped]
 .*/node_modules/express-graphql/.*
 .*/node_modules/graphql/.*
-.*/node_modules/mapbox-gl/src/.*
 
 [options]
 esproposal.optional_chaining=enable
 
-[libs]
-node_modules/mapbox-gl/flow-typed
-node_modules/mapbox-gl/dist/mapbox-gl.js.flow
-
 [declarations]
-.*/node_modules/relay-runtime/.*
-.*/node_modules/react-relay/.*
+.*/node_modules/.*
 .*\.graphql\.js
-.*/node_modules/react-beautiful-dnd/.*
 
 [lints]
 all=warn

--- a/fbcnms-packages/fbcnms-ui/insights/map/MapView.js
+++ b/fbcnms-packages/fbcnms-ui/insights/map/MapView.js
@@ -9,6 +9,7 @@
  */
 
 import type {ComponentType} from 'react';
+import type {CustomLayerInterface} from 'mapbox-gl/src/style/style_layer/custom_style_layer';
 import type {
   FilterSpecification,
   LayerSpecification,
@@ -35,9 +36,11 @@ type State = {
   map: ?mapboxgl.Map,
 };
 
+type LayerType = LayerSpecification | CustomLayerInterface;
+
 type Props = WithStyles<typeof styles> & {
   geojson: MagmaFeatureCollection,
-  mapLayers?: Array<LayerSpecification>,
+  mapLayers?: Array<LayerType>,
   MapMarker: ComponentType<MapMarkerProps>,
   onMarkerClick?: (string | number) => void,
   mapLayerFilters?: Map<string, FilterSpecification>,
@@ -87,7 +90,7 @@ class MapView extends React.Component<Props, State> {
   }
 
   initMap() {
-    const map = new mapboxgl.Map({
+    const map: mapboxgl.Map = new mapboxgl.Map({
       attributionControl: false,
       container: this.mapContainer,
       hash: false,
@@ -116,7 +119,7 @@ class MapView extends React.Component<Props, State> {
   };
 
   _updateLayers(
-    prevMapLayers?: Array<LayerSpecification>,
+    prevMapLayers?: Array<LayerType>,
     prevMapLayerFilters?: Map<string, FilterSpecification>,
   ): boolean {
     // returns true if displayed layers were updated

--- a/fbcnms-packages/fbcnms-ui/package.json
+++ b/fbcnms-packages/fbcnms-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "dependencies": {
     "@material-ui/core": "^4.0.0",
     "@material-ui/icons": "^4.0.0",


### PR DESCRIPTION
Summary:
Lib version of this PR: https://github.com/facebookincubator/symphony/pull/1221

The .flowconfig was incorrect for mapboxgl. This resulted in none of it actually being flowtyped at all.
This adds that back and fixes it.

Differential Revision: D23408144

