### PR TITLE
Fix flow error (#281)

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/components/rules/PrometheusEditor/ToggleableExpressionEditor.js
+++ b/fbcnms-packages/fbcnms-alarms/components/rules/PrometheusEditor/ToggleableExpressionEditor.js
@@ -26,6 +26,7 @@ import {makeStyles} from '@material-ui/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 
+import type {BinaryComparator} from '../../prometheus/PromQLTypes';
 import type {InputChangeFunc} from './PrometheusEditor';
 
 type prometheus_labelset = {
@@ -162,7 +163,14 @@ function ThresholdExpressionEditor(props: {
       </TextField>
     </Grid>
   );
-  const conditions = ['>', '<', '==', '>=', '<=', '!='];
+  const conditions: Array<BinaryComparator> = [
+    '>',
+    '<',
+    '==',
+    '>=',
+    '<=',
+    '!=',
+  ];
   const conditionSelector = (
     <Grid item>
       <InputLabel htmlFor="condition-input">Condition</InputLabel>
@@ -175,7 +183,10 @@ function ThresholdExpressionEditor(props: {
         onChange={({target}) => {
           props.onChange({
             ...props.expression,
-            comparator: new PromQL.BinaryComparator(target.value),
+            comparator: new PromQL.BinaryComparator(
+              // Cast to element type of conditions as it's item type
+              ((target.value: any): $ElementType<typeof conditions, 0>),
+            ),
           });
         }}>
         {conditions.map(item => (


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/terragraph-nms/pull/281

Pull Request resolved: https://github.com/facebookexternal/fbc/pull/3172

It seems like this introduced a flow error. I still have no idea why sandcastle doesn't catch it - my guess is that it has something to do with flow lazy being used? We actually dont even control the sandcastle job for it, it's a fb wide thing.

I fixed it by casting the string to any and then to the correct type - which is listed as being the same type as the items passed to the selector. This way, if the main type will change, at least it will be typechecked. Selectors have always been a pain point for flow, and I don't really know of a better way to do this.

Differential Revision: D23612332

