### PR TITLE
cut flow project size in half

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,7 @@
 [ignore]
 
+<PROJECT_ROOT>/node_modules/.*/node_modules/.*
+
 ; Ignore components that we dont care if they match our flow
 .*/node_modules/bcryptjs/.*
 .*/node_modules/config-chain/test/.*


### PR DESCRIPTION
Summary:
ideally flow wouldn't look at node_modules at all, and use libdefs from flow-typed instead. absent that, it needs to be able to see the files you require, so we can't completely ignore node_modules.

but product code should never require a transitive dependency like `require('foo/node_modules/bar')`, so we can ignore `node_modules/.*/node_modules/`.

before, flow was aware of > 101k files; after, 46k files

Reviewed By: tcirstea

Differential Revision: D23633937

