### PR TITLE
Fix logger 'event' field to match what Elasticsearch expects

### DIFF
--- a/fbcnms-packages/fbcnms-ui/utils/Logging.js
+++ b/fbcnms-packages/fbcnms-ui/utils/Logging.js
@@ -30,7 +30,7 @@ export const ServerLog = (topic: string) =>
           const {event, level, payload} = e;
           const {timestamp, data, user} = payload;
           return {
-            event,
+            event: {name: event},
             level,
             ts: timestamp / 1000,
             data,


### PR DESCRIPTION
Summary:
For some reason the 'event' field in Elasticsearch used to be a string but is now an object with the fields 'name', 'obj', and 'tenant'.  Elasticsearch was rejecting all web client log events because we were sending event as a string.

{F337091091}

Differential Revision: D23891347

