### PR TITLE
Include watchOptions in webpackMiddleware options

### DIFF
--- a/fbcnms-packages/fbcnms-express-middleware/package.json
+++ b/fbcnms-packages/fbcnms-express-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/express-middleware",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "@fbcnms/logging": "^0.1.0",
     "body-parser": "^1.18.3",

--- a/fbcnms-packages/fbcnms-express-middleware/webpackSmartMiddleware.js
+++ b/fbcnms-packages/fbcnms-express-middleware/webpackSmartMiddleware.js
@@ -33,6 +33,7 @@ function webpackDevMiddleware(options: WebpackMiddlewareOptions): Middleware {
   const middleware = webpackMiddleware(compiler, {
     publicPath: devWebpackConfig.output.publicPath,
     contentBase: 'src',
+    watchOptions: devWebpackConfig?.devServer?.watchOptions,
     logger,
     stats: {
       colors: true,


### PR DESCRIPTION
WatchOptions were being ignored by the webpack middleware causing
app to watch all directories under node_modules. This patch fixes the
issue

Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>