### PR TITLE
[alarms] update notistack version

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/components/Alarms.js
+++ b/fbcnms-packages/fbcnms-alarms/components/Alarms.js
@@ -25,7 +25,7 @@ import Typography from '@material-ui/core/Typography';
 import getPrometheusRuleInterface from './rules/PrometheusEditor/getRuleInterface';
 import useRouter from '../hooks/useRouter';
 import {Link, Redirect, Route, Switch} from 'react-router-dom';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {matchPath} from 'react-router';
 
 import type {ApiUtil} from './AlarmsApi';

--- a/fbcnms-packages/fbcnms-alarms/components/AlertRules.js
+++ b/fbcnms-packages/fbcnms-alarms/components/AlertRules.js
@@ -19,7 +19,7 @@ import TableAddButton from './table/TableAddButton';
 import axios from 'axios';
 import useRouter from '../hooks/useRouter';
 import {Parse} from './prometheus/PromQLParser';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from './AlarmContext';
 import {useEnqueueSnackbar} from '../hooks/useSnackbar';
 import {useLoadRules} from './hooks';

--- a/fbcnms-packages/fbcnms-alarms/components/SnackbarItem.js
+++ b/fbcnms-packages/fbcnms-alarms/components/SnackbarItem.js
@@ -17,7 +17,7 @@ import Typography from '@material-ui/core/Typography';
 import WarningIcon from '@material-ui/icons/Warning';
 import classNames from 'classnames';
 import {blue60, gray4, green, red, yellow} from '../theme/colors';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useSnackbar} from 'notistack';
 import {withForwardRef} from './ForwardRef';
 import type {ForwardRef} from './ForwardRef';

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/AlertDetails/AlertDetailsPane.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/AlertDetails/AlertDetailsPane.js
@@ -27,7 +27,7 @@ import Paper from '@material-ui/core/Paper';
 import SeverityIndicator from '../../severity/SeverityIndicator';
 import Typography from '@material-ui/core/Typography';
 import moment from 'moment';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../../AlarmContext';
 
 import type {

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/FiringAlerts.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/FiringAlerts.js
@@ -22,7 +22,7 @@ import useRouter from '../../hooks/useRouter';
 import {Link} from 'react-router-dom';
 import {SEVERITY} from '../severity/Severity';
 import {get} from 'lodash';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../AlarmContext';
 import {useEffect, useState} from 'react';
 import {useEnqueueSnackbar} from '../../hooks/useSnackbar';

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/Receivers/ConfigEditor.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/Receivers/ConfigEditor.js
@@ -17,7 +17,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import RootRef from '@material-ui/core/RootRef';
 import Typography from '@material-ui/core/Typography';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 
 export type Props = {
   RequiredFields: React.Node,

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/Receivers/GlobalConfig.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/Receivers/GlobalConfig.js
@@ -21,7 +21,7 @@ import Paper from '@material-ui/core/Paper';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import useForm from '../../../hooks/useForm';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/Receivers/Receivers.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/Receivers/Receivers.js
@@ -21,7 +21,7 @@ import SimpleTable from '../../table/SimpleTable';
 import TableActionDialog from '../../table/TableActionDialog';
 import TableAddButton from '../../table/TableAddButton';
 import useRouter from '../../../hooks/useRouter';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 import type {AlertReceiver} from '../../AlarmAPIType';

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/Routes.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/Routes.js
@@ -15,7 +15,7 @@ import React from 'react';
 import SimpleTable, {toLabels} from '../table/SimpleTable';
 import TableActionDialog from '../table/TableActionDialog';
 import useRouter from '../../hooks/useRouter';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../AlarmContext';
 import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
 import {useState} from 'react';

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/Suppressions.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/Suppressions.js
@@ -15,7 +15,7 @@ import React from 'react';
 import SimpleTable, {toLabels} from '../table/SimpleTable';
 import TableActionDialog from '../table/TableActionDialog';
 import useRouter from '../../hooks/useRouter';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../AlarmContext';
 import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
 import {useState} from 'react';

--- a/fbcnms-packages/fbcnms-alarms/components/common/Editor.js
+++ b/fbcnms-packages/fbcnms-alarms/components/common/Editor.js
@@ -14,7 +14,7 @@ import * as React from 'react';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 
 export type Props = {
   children: React.Node,

--- a/fbcnms-packages/fbcnms-alarms/components/rules/AddEditRule.js
+++ b/fbcnms-packages/fbcnms-alarms/components/rules/AddEditRule.js
@@ -10,7 +10,7 @@
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import RuleContext from './RuleContext';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../AlarmContext';
 import {useState} from 'react';
 

--- a/fbcnms-packages/fbcnms-alarms/components/rules/PrometheusEditor/PrometheusEditor.js
+++ b/fbcnms-packages/fbcnms-alarms/components/rules/PrometheusEditor/PrometheusEditor.js
@@ -28,7 +28,7 @@ import useRouter from '../../../hooks/useRouter';
 import {Labels} from '../../prometheus/PromQL';
 import {Parse} from '../../prometheus/PromQLParser';
 import {SEVERITY} from '../../severity/Severity';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 

--- a/fbcnms-packages/fbcnms-alarms/components/rules/PrometheusEditor/ToggleableExpressionEditor.js
+++ b/fbcnms-packages/fbcnms-alarms/components/rules/PrometheusEditor/ToggleableExpressionEditor.js
@@ -22,7 +22,7 @@ import TextField from '@material-ui/core/TextField';
 import useRouter from '../../../hooks/useRouter';
 import {LABEL_OPERATORS} from '../../prometheus/PromQLTypes';
 import {groupBy} from 'lodash';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 

--- a/fbcnms-packages/fbcnms-alarms/components/rules/SelectRuleType.js
+++ b/fbcnms-packages/fbcnms-alarms/components/rules/SelectRuleType.js
@@ -13,7 +13,7 @@ import Grid from '@material-ui/core/Grid';
 import InputLabel from '@material-ui/core/InputLabel';
 import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import type {RuleInterfaceMap} from './RuleInterface';
 
 const useRuleTypeStyles = makeStyles(theme => ({

--- a/fbcnms-packages/fbcnms-alarms/components/severity/SeverityIndicator.js
+++ b/fbcnms-packages/fbcnms-alarms/components/severity/SeverityIndicator.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
 import {SEVERITY} from './Severity';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({
   // the circle

--- a/fbcnms-packages/fbcnms-alarms/components/table/SimpleTable.js
+++ b/fbcnms-packages/fbcnms-alarms/components/table/SimpleTable.js
@@ -19,7 +19,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {withStyles} from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({

--- a/fbcnms-packages/fbcnms-alarms/components/table/TableActionDialog.js
+++ b/fbcnms-packages/fbcnms-alarms/components/table/TableActionDialog.js
@@ -14,7 +14,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
   paper: {

--- a/fbcnms-packages/fbcnms-alarms/components/table/TableAddButton.js
+++ b/fbcnms-packages/fbcnms-alarms/components/table/TableAddButton.js
@@ -13,7 +13,7 @@
 import * as React from 'react';
 import AddIcon from '@material-ui/icons/Add';
 import Fab from '@material-ui/core/Fab';
-import {makeStyles} from '@material-ui/styles';
+import {makeStyles} from '@material-ui/core/styles';
 
 type Props = {
   label: string,

--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -3,7 +3,7 @@
   "description": "UI components for alert configuration of prometheus and alertmanager.",
   "author": "Facebook Connectivity",
   "license": "BSD-2-Clause",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebookincubator/fbc-js-core.git",
@@ -25,7 +25,7 @@
     "moment": "^2.24.0",
     "moo": "^0.5.1",
     "nearley": "^2.19.0",
-    "notistack": "^0.8.5"
+    "notistack": "^1.0.3"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/fbcnms-packages/fbcnms-ui/package.json
+++ b/fbcnms-packages/fbcnms-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "dependencies": {
     "@material-ui/core": "^4.0.0",
     "@material-ui/icons": "^4.0.0",
@@ -10,7 +10,7 @@
     "beaver-logger": "^4.0.12",
     "immutable": "^4.0.0-rc.12",
     "mapbox-gl": "^0.53.0",
-    "notistack": "^0.8.5",
+    "notistack": "^1.0.3",
     "react": "^16.8.6",
     "react-autosuggest": "^9.4.3",
     "react-chartjs-2": "^2.7.4",

--- a/flow-typed/npm/@material-ui/core_v1.x.x.js
+++ b/flow-typed/npm/@material-ui/core_v1.x.x.js
@@ -2495,6 +2495,9 @@ declare module "@material-ui/core/styles" {
 
   declare module.exports: {
     MuiThemeProvider: $Exports<"@material-ui/core/styles/MuiThemeProvider">,
+    makeStyles: <Props, Stl: Style<Props, string>>(
+      Theme => Stl,
+    ) => StyleHookFn<Props, Stl>,
     withStyles: $Exports<"@material-ui/core/styles/withStyles">,
     withTheme: $Exports<"@material-ui/core/styles/withTheme">,
     createGenerateClassName: $Exports<"@material-ui/core/styles/createGenerateClassName">,
@@ -3954,6 +3957,9 @@ declare module "@material-ui/core/styles/transitions.js" {
 declare module "@material-ui/core/styles/withStyles.js" {
   declare module.exports: $Exports<"@material-ui/core/styles/withStyles">;
 }
+declare module "@material-ui/core/styles/makeStyles.js" {
+  declare module.exports: $Exports<"@material-ui/core/styles/makeStyles">;
+}
 declare module "@material-ui/core/styles/withTheme.js" {
   declare module.exports: $Exports<"@material-ui/core/styles/withTheme">;
 }
@@ -4348,6 +4354,9 @@ declare module "@material-ui/core" {
   >;
   declare export var withStyles: $Exports<
     "@material-ui/core/styles/withStyles"
+  >;
+  declare export var makeStyles: $Exports<
+    "@material-ui/core/styles/makeStyles"
   >;
   declare export var withTheme: $Exports<"@material-ui/core/styles/withTheme">;
   declare export var createMuiTheme: $Exports<


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

To fix a security vulnerability of notistack.

Also had to do some small changes to material-ui stuff that was being imported improperly as of 4.0 which was breaking things in the snackbar.
https://github.com/mui-org/material-ui/issues/15976#issuecomment-499774398

Tested by publishing new version to private repo (verdaccio) and running prometheus-configmanager UI with the new package: 
![image](https://user-images.githubusercontent.com/13274915/108574577-a90c9100-72cc-11eb-9556-1186c093c0f4.png)
