### PR TITLE
Support postgres in sequelize-models

### DIFF
--- a/fbcnms-packages/fbcnms-sequelize-models/index.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/index.js
@@ -47,6 +47,14 @@ export function jsonArrayContains(column: string, value: string) {
     sequelize.getDialect() === 'mariadb'
   ) {
     return Sequelize.fn('JSON_CONTAINS', Sequelize.col(column), `"${value}"`);
+  } else if (sequelize.getDialect() === 'postgres') {
+    const escapedColumn = sequelize
+      .getQueryInterface()
+      .quoteIdentifier(column, true);
+    const escapedValue = sequelize
+      .getQueryInterface()
+      .quoteIdentifier(value, true);
+    return Sequelize.literal(`${escapedColumn}::jsonb @> '${escapedValue}'`);
   } else {
     // sqlite
     const escapedColumn = sequelize

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "sequelize": "^5.8.5"
   }


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->

When `sequelize-models` is configured to use Postgres, incorrect queries are constructed for the equivalent of JSON_CONTAINS. This pull request adds a else-if branch to `jsonArrayContains` function to support the `postgres` sql dialect for sequelize-models.

See (https://github.com/facebookincubator/fbc-js-core/pull/73)

Tested manually using a Magma NMS setup with manually modified dependencies.