### PR TITLE
Support postgres in express-middleware

### DIFF
--- a/fbcnms-packages/fbcnms-express-middleware/package.json
+++ b/fbcnms-packages/fbcnms-express-middleware/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@fbcnms/express-middleware",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "@fbcnms/logging": "^0.1.0",
+    "@fbcnms/sequelize-models": "^0.1.1",
     "body-parser": "^1.18.3",
     "compression": "^1.7.1",
     "cookie-parser": "^1.4.3",

--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@fbcnms/platform-server",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "dependencies": {
     "@fbcnms/auth": "^0.1.0",
     "@fbcnms/babel-register": "^0.1.0",
     "@fbcnms/express-middleware": "^0.1.0",
     "@fbcnms/logging": "^0.1.0",
     "@fbcnms/magma-api": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.0",
+    "@fbcnms/sequelize-models": "^0.1.1",
     "@fbcnms/types": "^0.1.10",
     "@fbcnms/util": "^0.1.0",
     "add": "^2.0.6",


### PR DESCRIPTION
<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->

When `sequelize-models` is configured to use Postgres, incorrect queries are constructed for the equivalent of JSON_CONTAINS. This pull request updates `express-middleware` to use the updated version of `sequelize-models` which no longer has this issue. See (https://github.com/facebookincubator/fbc-js-core/pull/72)

Tested manually using a Magma NMS setup with manually modified dependencies.