### PR TITLE
Add DB data migration script to fbcnms/sequelize-models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Halt on no changes 
+          name: Halt on no changes
           working_directory: fbcnms-packages/<<parameters.package_dir>>
           command: |
             published=$(npm -s show <<parameters.package_name>> version || exit 0)

--- a/fbcnms-packages/fbcnms-sequelize-models/README.md
+++ b/fbcnms-packages/fbcnms-sequelize-models/README.md
@@ -1,0 +1,41 @@
+# fbcnms-sequelize-models
+
+## dbDataMigration Usage
+
+Used for migration of sequelize-models data from one DB to another
+
+**Example: Manual Usage**
+```
+$ yarn start
+
+? Enter Source DB host: mariadb
+? Enter Source DB port: 3306
+? Enter Source DB database name: nms
+? Enter Source DB username: root
+? Enter Source DB password: [hidden]
+? Enter Source DB SQL dialect: mariadb
+
+Source DB Connection Config:
+---------------------------
+Host: mariadb:3306
+Database: nms
+Username: root
+Dialect: mariadb
+
+? Would you like to run data migration with these settings?: Yes
+Completed data migration to target DB
+```
+
+**Example: Automated Usage**
+```
+$ npm start -- --username=nms --password=nms --database=nms --host=mariadb --port=3306 --dialect=mariadb --confirm
+
+Source DB Connection Config:
+---------------------------
+Host: mariadb:3306
+Database: nms
+Username: nms
+Dialect: mariadb
+
+Completed data migration to target DB
+```

--- a/fbcnms-packages/fbcnms-sequelize-models/dbDataMigration.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/dbDataMigration.js
@@ -1,0 +1,224 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+/**
+ * Script for migration of sequelize-models data from one DB to another.
+ *
+ * Two databases are involved in this script, denoted as the source
+ * database, and the target database.
+ * After a successful run of this script, both the source and target
+ * data should exist on the target database.
+ *
+ * While the source DB connection options must be specified,
+ * the target DB connection is established automatically using
+ * environment variables.
+ *
+ *
+ * Script arguments (specifies source DB only):
+ * --username:          DB username
+ * --password:          DB password
+ * --host:              DB host
+ * --port:              DB port
+ * --dialect:           DB SQL dialect
+ * --confirm: skip final confirmation to run migration
+ *
+ * Example Usage:
+ *  $ node -r @fbcnms/babel-register main.js
+ *  ? Enter Source DB host: mariadb
+ *  ? Enter Source DB port: 3306
+ *  ? Enter Source DB database name: nms
+ *  ? Enter Source DB username: root
+ *  ? Enter Source DB password: [hidden]
+ *  ? Enter Source DB SQL dialect: mariadb
+ *
+ *  Source DB Connection Config:
+ *  ---------------------------
+ *  Host: mariadb:3306
+ *  Database: nms
+ *  Username: root
+ *  Dialect: mariadb
+ *
+ *  ? Would you like to run data migration with these settings?: Yes
+ *  Completed data migration to target DB
+ */
+
+/* eslint no-console: "off" */
+
+const inquirer = require('inquirer');
+const process = require('process');
+const argv = require('minimist')(process.argv.slice(2));
+const {importFromDatabase} = require('./index');
+import {User} from './index';
+import type {Options} from 'sequelize';
+
+const dbQuestions = [
+  {
+    type: 'input',
+    name: 'host',
+    message: 'Enter Source DB host:',
+    default: 'mariadb',
+  },
+  {
+    type: 'input',
+    name: 'port',
+    message: 'Enter Source DB port:',
+    default: 3306,
+  },
+  {
+    type: 'input',
+    name: 'database',
+    message: 'Enter Source DB database name:',
+    default: 'nms',
+  },
+  {
+    type: 'input',
+    name: 'username',
+    message: 'Enter Source DB username:',
+    default: 'root',
+  },
+  {
+    type: 'password',
+    name: 'password',
+    message: 'Enter Source DB password:',
+  },
+  {
+    type: 'input',
+    name: 'dialect',
+    message: 'Enter Source DB SQL dialect:',
+    default: 'mariadb',
+  },
+];
+
+async function isMigrationNeeded(): Promise<boolean> {
+  try {
+    const allUsers = await User.findAll();
+    if (allUsers.length > 0) {
+      console.warn('Users found in target DB. Migration may already have run');
+      return await false;
+    }
+    return await true;
+  } catch (e) {
+    console.error(
+      `Unable to run migration. Connection error to target database: \n` +
+        `------------------------\n` +
+        `${e} \n` +
+        `------------------------\n`,
+    );
+    process.exit(1);
+  }
+  return await false;
+}
+
+async function getDbOptions(): Promise<Options> {
+  let dbOptions: Options = {};
+
+  if (
+    argv['username'] &&
+    argv['password'] &&
+    argv['database'] &&
+    argv['host'] &&
+    argv['port'] &&
+    argv['dialect']
+  ) {
+    dbOptions = {
+      username: argv['username'],
+      password: argv['password'],
+      database: argv['database'],
+      host: argv['host'],
+      port: parseInt(argv['port']),
+      dialect: argv['dialect'],
+      logging: (msg: string) => console.log(msg),
+    };
+    console.log(argv);
+  } else {
+    await inquirer.prompt(dbQuestions).then(answers => {
+      dbOptions = {
+        username: answers['username'],
+        password: answers['password'],
+        database: answers['database'],
+        host: answers['host'],
+        port: parseInt(answers['port']),
+        dialect: answers['dialect'],
+        logging: (msg: string) => console.log(msg),
+      };
+    });
+  }
+  return dbOptions;
+}
+
+function displayDbOptions(dbOptions: Options) {
+  const notice =
+    `\n` +
+    `Source DB Connection Config:\n` +
+    `---------------------------\n` +
+    `Host: ${dbOptions.host || ''}:${dbOptions.port || 0} \n` +
+    `Database: ${dbOptions.database || ''} \n` +
+    `Username: ${dbOptions.username || ''} \n` +
+    `Dialect: ${dbOptions.dialect || ''} \n`;
+
+  console.log(notice);
+}
+
+async function confirmAndRunMigration(dbOptions: Options): Promise<void> {
+  if (argv['confirm']) {
+    await runMigration(dbOptions);
+    return;
+  }
+
+  await inquirer
+    .prompt([
+      {
+        type: 'confirm',
+        name: 'willRun',
+        message: 'Would you like to run data migration with these settings?:',
+      },
+    ])
+    .then(confirmation => {
+      if (confirmation['willRun']) {
+        (async () => {
+          await runMigration(dbOptions);
+        })();
+        return;
+      }
+      console.log('Aborting data migration');
+    });
+}
+
+async function runMigration(dbOptions: Options): Promise<void> {
+  try {
+    await importFromDatabase(dbOptions);
+    console.log('Completed data migration to target DB');
+  } catch (error) {
+    console.log(
+      `Unable to connect to source database for migration:\n` +
+        `--------------------------------------------------------------------------\n` +
+        `${error}\n` +
+        `--------------------------------------------------------------------------\n`,
+    );
+    process.exit(1);
+  }
+}
+
+function main() {
+  (async () => {
+    const willRunMigration = await isMigrationNeeded();
+    if (!willRunMigration) {
+      console.log('Skipping migration from source DB');
+      return;
+    }
+
+    const dbOptions: Options = await getDbOptions();
+    displayDbOptions(dbOptions);
+
+    await confirmAndRunMigration(dbOptions);
+  })();
+}
+
+main();

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.2",
+  "version": "0.1.3",
+  "scripts": {
+    "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
+},
   "dependencies": {
+    "@fbcnms/babel-register": "^0.1.0",
+    "inquirer": "^8.0.0",
+    "mariadb": "^2.4.2",
+    "minimist": "^1.2.5",
     "sequelize": "^5.8.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2829,6 +2829,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/geojson@^7946.0.7":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
+
 "@types/glob-base@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/glob-base/-/glob-base-0.3.0.tgz#a581d688347e10e50dd7c17d6f2880a10354319d"
@@ -2939,6 +2944,11 @@
   version "14.0.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
   integrity sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
+
+"@types/node@^14.14.28":
+  version "14.14.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
+  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
 "@types/npmlog@^4.1.2":
   version "4.1.2"
@@ -4994,7 +5004,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -5171,6 +5181,11 @@ cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cli@~1.0.0:
   version "1.0.1"
@@ -8523,6 +8538,13 @@ iconv-lite@^0.5.0:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -8743,6 +8765,25 @@ inquirer@^7.0.0:
     mute-stream "0.0.8"
     run-async "^2.4.0"
     rxjs "^6.5.3"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
+inquirer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.0.0.tgz#957a46db1abcf0fdd2ab82deb7470e90afc7d0ac"
+  integrity sha512-ON8pEJPPCdyjxj+cxsYRe6XfCJepTxANdNnTebsTuQgXpRyZRRT9t4dJwjRubgmvn20CLSEnozRUayXyM9VTXA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.6"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -10337,7 +10378,7 @@ lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@^4.17.4:
+lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10513,6 +10554,19 @@ mapbox-gl@^0.53.0:
     supercluster "^6.0.1"
     tinyqueue "^2.0.0"
     vt-pbf "^3.1.1"
+
+mariadb@^2.4.2:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/mariadb/-/mariadb-2.5.3.tgz#13a2267f7f1b572f9db997aaaa8c00f75d5a87e8"
+  integrity sha512-9ZbQ1zLqasLCQy6KDcPHtX7EUIMBlQ8p64gNR61+yfpCIWjPDji3aR56LvwbOz1QnQbVgYBOJ4J/pHoFN5MR+w==
+  dependencies:
+    "@types/geojson" "^7946.0.7"
+    "@types/node" "^14.14.28"
+    denque "^1.4.1"
+    iconv-lite "^0.6.2"
+    long "^4.0.0"
+    moment-timezone "^0.5.33"
+    please-upgrade-node "^3.2.0"
 
 markdown-escapes@^1.0.0:
   version "1.0.4"
@@ -10906,6 +10960,13 @@ moment-timezone@^0.5.21, moment-timezone@^0.5.31:
   version "0.5.31"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"
   integrity sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==
+  dependencies:
+    moment ">= 2.9.0"
+
+moment-timezone@^0.5.33:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
   dependencies:
     moment ">= 2.9.0"
 
@@ -12014,6 +12075,13 @@ pkg-up@3.1.0, pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 plugin-error@^0.1.2:
   version "0.1.2"
@@ -13729,6 +13797,13 @@ rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.6.6:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
+  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -13756,7 +13831,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -13816,6 +13891,11 @@ select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
   integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

Adds a `dbDataMigration` script to `fbcnms/sequelize-models`, intended to be used to sequelize-models data from one DB to another.

This package will be first used for migrating the Magma NMS DB data to share with Magma orc8r DB, allowing network operators to run on a single AWS RDS instance, or allow for other simpler, or cheaper setups. This is intended to be used as a script pre-upgrade from v1.4 to v1.5

**Example: Manual Usage**
```
$ yarn start

? Enter Source DB host: mariadb
? Enter Source DB port: 3306
? Enter Source DB database name: nms
? Enter Source DB username: root
? Enter Source DB password: [hidden]
? Enter Source DB SQL dialect: mariadb

Source DB Connection Config:
---------------------------
Host: mariadb:3306
Database: nms
Username: root
Dialect: mariadb

? Would you like to run data migration with these settings?: Yes
Completed data migration to target DB
```

**Example: Automated Usage**
```
$ npm start -- --username=nms --password=nms --database=nms --host=mariadb --port=3306 --dialect=mariadb --confirm

Source DB Connection Config:
---------------------------
Host: mariadb:3306
Database: nms
Username: nms
Dialect: mariadb

Completed data migration to target DB
```


It is intended that this package will be mainly run in an automated fashion.