### PR TITLE
Support bidirectional DB data migration in fbcnms-sequelize-models

### DIFF
--- a/fbcnms-packages/fbcnms-sequelize-models/README.md
+++ b/fbcnms-packages/fbcnms-sequelize-models/README.md
@@ -6,36 +6,37 @@ Used for migration of sequelize-models data from one DB to another
 
 **Example: Manual Usage**
 ```
-$ yarn start
+$ yarn dbDataMigrate
 
-? Enter Source DB host: mariadb
-? Enter Source DB port: 3306
-? Enter Source DB database name: nms
-? Enter Source DB username: root
-? Enter Source DB password: [hidden]
-? Enter Source DB SQL dialect: mariadb
+? Enter DB host: mariadb
+? Enter DB port: 3306
+? Enter DB database name: nms
+? Enter DB username: root
+? Enter DB password: [hidden]
+? Enter DB SQL dialect: mariadb
 
-Source DB Connection Config:
+DB Connection Config:
 ---------------------------
 Host: mariadb:3306
 Database: nms
 Username: root
 Dialect: mariadb
 
+? Are you importing from the specified DB, or exporting to it?: import
 ? Would you like to run data migration with these settings?: Yes
-Completed data migration to target DB
+Completed data migration, importing from specified DB
 ```
 
 **Example: Automated Usage**
 ```
-$ npm start -- --username=nms --password=nms --database=nms --host=mariadb --port=3306 --dialect=mariadb --confirm
+$ npm dbDataMigrate -- --username=nms --password=nms --database=nms --host=mariadb --port=3306 --dialect=mariadb --export --confirm
 
-Source DB Connection Config:
+DB Connection Config:
 ---------------------------
 Host: mariadb:3306
 Database: nms
 Username: nms
 Dialect: mariadb
 
-Completed data migration to target DB
+Completed data migration, exporting to specified DB
 ```

--- a/fbcnms-packages/fbcnms-sequelize-models/index.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/index.js
@@ -101,6 +101,32 @@ export async function importFromDatabase(sourceConfig: Options) {
   await User.bulkCreate(getDataValues(user));
 }
 
+export async function exportToDatabase(targetConfig: Options) {
+  const targetSequelize = new Sequelize(
+    targetConfig.database || '',
+    targetConfig.username,
+    targetConfig.password,
+    targetConfig,
+  );
+  const targetDb = createNmsDb(targetSequelize);
+
+  // $FlowIgnore findAll function exists for AuditLogEntry
+  const auditLogEntries = await AuditLogEntry.findAll();
+  await targetDb.AuditLogEntry.bulkCreate(getDataValues(auditLogEntries));
+
+  // $FlowIgnore findAll function exists for FeatureFlag
+  const featureFlags = await FeatureFlag.findAll();
+  await targetDb.FeatureFlag.bulkCreate(getDataValues(featureFlags));
+
+  // $FlowIgnore findAll function exists for Organization
+  const organization = await Organization.findAll();
+  await targetDb.Organization.bulkCreate(getDataValues(organization));
+
+  // $FlowIgnore findAll function exists for User
+  const user = await User.findAll();
+  await targetDb.User.bulkCreate(getDataValues(user));
+}
+
 // eslint-disable-next-line flowtype/no-weak-types
 function getDataValues(sequelizeModels: Array<Object>): Array<Object> {
   return sequelizeModels.map(model => model.dataValues);

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "scripts": {
     "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
 },


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

Modifies the `dbDataMigration` script to `fbcnms/sequelize-models`, intended to be used to sequelize-models data from one DB to another. This PR adds ability to either import from the specified DB, or export to the specified DB.

This package will be first used for migrating the Magma NMS DB data to share with Magma orc8r DB, allowing network operators to run on a single AWS RDS instance, or allow for other simpler, or cheaper setups. This is intended to be used as a script pre-upgrade from v1.4 to v1.5

**Example: Manual Usage**
```
$ yarn dbDataMigrate

? Enter DB host: mariadb
? Enter DB port: 3306
? Enter DB database name: nms
? Enter DB username: root
? Enter DB password: [hidden]
? Enter DB SQL dialect: mariadb

DB Connection Config:
---------------------------
Host: mariadb:3306
Database: nms
Username: root
Dialect: mariadb

? Are you importing from the specified DB, or exporting to it?: import
? Would you like to run data migration with these settings?: Yes
Completed data migration, importing from specified DB
```

**Example: Automated Usage**
```
$ npm dbDataMigrate -- --username=nms --password=nms --database=nms --host=mariadb --port=3306 --dialect=mariadb --export --confirm

DB Connection Config:
---------------------------
Host: mariadb:3306
Database: nms
Username: nms
Dialect: mariadb

Completed data migration, exporting to specified DB
```


It is intended that this package will be mainly run in an automated fashion.