### PR TITLE
[sequelize-models] Changed env variables to specify DB

### DIFF
--- a/fbcnms-packages/fbcnms-sequelize-models/README.md
+++ b/fbcnms-packages/fbcnms-sequelize-models/README.md
@@ -1,8 +1,54 @@
 # fbcnms-sequelize-models
 
-## dbDataMigration Usage
+A NMS-specific wrapper around the [Sequelize ORM](https://sequelize.org/).
 
-Used for migration of sequelize-models data from one DB to another
+Sequelize-models includes pre-defined models for common NMS entities such as organizations,
+users, feature flags, and even audit log entries.
+
+---
+
+## Usage
+
+Sequelize-models uses the DB specified by the following environment variables:
+- `DB_HOST`
+- `DB_PORT`
+- `DB_USER`
+- `DB_PASS`
+- `DB_NAME`
+- `DB_DIALECT`
+
+
+**Organization Usage**
+```
+import {Organization} from '@fbcnms/sequelize-models';
+
+async function findOrganization(orgName) {
+  const org = await Organization.findOne({
+    where: {
+      name: orgName,
+    },
+  });
+  return org;
+}
+
+async createDefaultOrganization() {
+  await Organization.create({
+    name: organization,
+    tab: ['inventory', 'nms'],
+    networkIDs: [],
+    csvCharset: '',
+    ssoCert: '',
+    ssoIssuer: '',
+    ssoEntrypoint: '',
+  });
+}
+```
+
+---
+
+## DB Data Migration Usage
+
+Functionality is also provided if you need to migrate your data between databases.
 
 **Example: Manual Usage**
 ```

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "scripts": {
     "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
 },

--- a/fbcnms-packages/fbcnms-sequelize-models/sequelizeConfig.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/sequelizeConfig.js
@@ -11,12 +11,12 @@
 import type {Options} from 'sequelize';
 
 // TODO: Pull from shared config
-const MYSQL_HOST = process.env.MYSQL_HOST || '127.0.0.1';
-const MYSQL_PORT = parseInt(process.env.MYSQL_PORT || '3306');
-const MYSQL_USER = process.env.MYSQL_USER || 'root';
-const MYSQL_PASS = process.env.MYSQL_PASS || '';
-const MYSQL_DB = process.env.MYSQL_DB || 'cxl';
-const MYSQL_DIALECT = process.env.MYSQL_DIALECT || 'mysql';
+const DB_HOST = process.env.DB_HOST || '127.0.0.1';
+const DB_PORT = parseInt(process.env.DB_PORT || '3306');
+const DB_USER = process.env.DB_USER || 'root';
+const DB_PASS = process.env.DB_PASS || '';
+const DB_NAME = process.env.DB_NAME || 'cxl';
+const DB_DIALECT = process.env.DB_DIALECT || 'mysql';
 
 const logger = require('@fbcnms/logging').getLogger(module);
 
@@ -29,21 +29,21 @@ const config: {[string]: Options} = {
     logging: false,
   },
   development: {
-    username: MYSQL_USER,
-    password: MYSQL_PASS,
-    database: MYSQL_DB,
-    host: MYSQL_HOST,
-    port: MYSQL_PORT,
-    dialect: MYSQL_DIALECT,
+    username: DB_USER,
+    password: DB_PASS,
+    database: DB_NAME,
+    host: DB_HOST,
+    port: DB_PORT,
+    dialect: DB_DIALECT,
     logging: (msg: string) => logger.debug(msg),
   },
   production: {
-    username: MYSQL_USER,
-    password: MYSQL_PASS,
-    database: MYSQL_DB,
-    host: MYSQL_HOST,
-    port: MYSQL_PORT,
-    dialect: MYSQL_DIALECT,
+    username: DB_USER,
+    password: DB_PASS,
+    database: DB_NAME,
+    host: DB_HOST,
+    port: DB_PORT,
+    dialect: DB_DIALECT,
     logging: (msg: string) => logger.debug(msg),
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,6 +1474,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@fbcnms/sequelize-models@^0.1.1":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.4.tgz#72d921fcd53981059d83209d7bcc6687f74e87aa"
+  integrity sha512-G3xzFb4jHbeRICGo0o4f379DYVM+SwZnxCnA0fp47d5KlrZHAuJdejMnVJ3P+EebXYK+WXmfisQKqiB8t1XK4g==
+  dependencies:
+    "@fbcnms/babel-register" "^0.1.0"
+    inquirer "^8.0.0"
+    mariadb "^2.4.2"
+    minimist "^1.2.5"
+    sequelize "^5.8.5"
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

The DB that sequelize-models connects to is specified through env variables. These have been renamed, removing the prefix of `MYSQL`, as it does not need to be mysql specific.

The version has also been updated from `0.1.4` to `1.0.0` to reflect the incompatible API changes.

The `README.md` has also been updated with basic usage.
