### PR TITLE
[sequelize-models] Fix db data migration mishandling null column values

### DIFF
--- a/fbcnms-packages/fbcnms-sequelize-models/dbDataMigration.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/dbDataMigration.js
@@ -56,7 +56,6 @@ const inquirer = require('inquirer');
 const process = require('process');
 const argv = require('minimist')(process.argv.slice(2));
 const {exportToDatabase, importFromDatabase} = require('./index');
-import {User} from './index';
 import type {Options} from 'sequelize';
 
 const dbQuestions = [
@@ -96,26 +95,6 @@ const dbQuestions = [
     default: 'mariadb',
   },
 ];
-
-async function isMigrationNeeded(): Promise<boolean> {
-  try {
-    const allUsers = await User.findAll();
-    if (allUsers.length > 0) {
-      console.warn('Users found in target DB. Migration may already have run');
-      return await false;
-    }
-    return await true;
-  } catch (e) {
-    console.error(
-      `Unable to run migration. Connection error to target database: \n` +
-        `------------------------\n` +
-        `${e} \n` +
-        `------------------------\n`,
-    );
-    process.exit(1);
-  }
-  return await false;
-}
 
 async function getDbOptions(): Promise<Options> {
   let dbOptions: Options = {};
@@ -211,10 +190,10 @@ async function runMigration(
   try {
     if (isImport) {
       await importFromDatabase(dbOptions);
-      console.log('Completed data migration, importing from specified DB');
+      console.log('Completed data migration, imported from specified DB');
     } else {
       await exportToDatabase(dbOptions);
-      console.log('Completed data migration, exporting to specified DB');
+      console.log('Completed data migration, exported to specified DB');
     }
   } catch (error) {
     console.log(
@@ -229,15 +208,8 @@ async function runMigration(
 
 function main() {
   (async () => {
-    const willRunMigration = await isMigrationNeeded();
-    if (!willRunMigration) {
-      console.log('Skipping DB migration');
-      return;
-    }
-
     const dbOptions: Options = await getDbOptions();
     displayDbOptions(dbOptions);
-
     await confirmAndRunMigration(dbOptions);
   })();
 }

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "scripts": {
     "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
 },


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Updated `@fbcnms/sequelize-models` to `0.1.5`

Two bug fixes included in this update:
1. The `tabs` column in the `Organizations` and `Users` table can be null sometimes, despite being specified as non-null in the sequelize models. The data migration methods account for this by providing default values.
2. Method `isMigrationNeeded` always checks the DB specified by the env variables. This has been fixed to check the 'target' DB instead, which may not be the DB specified by env variables. (If migrating from DB 'A' to DB 'B', the 'target' in this case would be 'B')

Please no comments on code being slightly redundant. Refactoring changes to be included in another PR after this is merged.

## Testing

This PR has been manually tested on a Magma orchestrator/NMS setup managed through kubernetes. The yarn command for db data migration was run on the NMS pod. See example logs here:

```
bash-5.0# yarn dbDataMigrate
yarn run v1.22.5
warning package.json: No license field
$ node -r @fbcnms/babel-register dbDataMigration.js
? Enter DB host: orc8r.asdf.eu-west-1.rds.amazonaws.com:5432
? Enter DB port: 5432
? Enter DB database name: magma
? Enter DB username: magma
? Enter DB password: [hidden]
? Enter DB SQL dialect: postgres

DB Connection Config:
---------------------------
Host: orc8r.asdf.eu-west-1.rds.amazonaws.com:5432
Database: magma
Username: magma
Dialect: postgres

? Are you importing from the specified DB, or exporting to it?: export
? Would you like to run data migration with these settings?: Yes

...

Completed data migration, exported to specified DB
Done in 54.25s.
bash-5.0#
```

After running the script, the Postgres database was manually verified for creation of specified tables, and existence of the correct data.