### PR TITLE
[sequelize-models] Migrate SequelizeMeta table during db data migration

### DIFF
--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "scripts": {
     "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
 },


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

During DB data migration function through the `sequelize-models` package, the SequelizeMeta table needs to be migrated as well. This table is used by Sequelize to keep track of what sequelize migrations have run, and if this table is not migrated, then the same migrations will re-run, leading to issues.

## Test Plan

Tested manually on a k8s setup, verifying that the `SequelizeMeta` table was created, and included all the rows from the original table. Also verified that the sequelize migrations would not re-run.
