### PR TITLE
[sequelize-models] Add migration for new default in Users/tabs

### DIFF
--- a/fbcnms-packages/fbcnms-sequelize-models/migrations/20210427134100-user-tabs-default.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/migrations/20210427134100-user-tabs-default.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {DataTypes, QueryInterface} from 'sequelize';
+
+module.exports = {
+  up: (queryInterface: QueryInterface, types: DataTypes) => {
+    return queryInterface.changeColumn('Users', 'tabs', {
+      allowNull: true,
+      defaultValue: [],
+      type: types.JSON,
+    });
+  },
+
+  down: (queryInterface: QueryInterface, types: DataTypes) => {
+    return queryInterface.changeColumn('Users', 'tabs', {
+      allowNull: true,
+      defaultValue: '[]',
+      type: types.JSON,
+    });
+  },
+};

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "scripts": {
     "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
 },


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

Fixes a bug where users of the `@fbcnms/sequelize-models` package expect the `tabs` field to be an array, but find it to be a string instead. This changes the default value to avoid this issue.

**Before**:
```
nms=# \d "Users"
                                           Table "public.Users"
      Column      |           Type           | Collation | Nullable |               Default
------------------+--------------------------+-----------+----------+-------------------------------------
 id               | integer                  |           | not null | nextval('"Users_id_seq"'::regclass)
 email            | character varying(255)   |           | not null |
 password         | character varying(255)   |           | not null |
 role             | integer                  |           | not null | 0
 createdAt        | timestamp with time zone |           | not null |
 updatedAt        | timestamp with time zone |           | not null |
 networkIDs       | json                     |           | not null | '"[]"'::json
 verificationType | integer                  |           | not null | 0
 organization     | character varying(255)   |           | not null | 'fb-test'::character varying
 readOnly         | boolean                  |           | not null | false
 tabs             | json                     |           |          | '"[]"'::json
Indexes:
    "Users_pkey" PRIMARY KEY, btree (id)
```

**After**:
```
nms=# \d "Users"
                                           Table "public.Users"
      Column      |           Type           | Collation | Nullable |               Default
------------------+--------------------------+-----------+----------+-------------------------------------
 id               | integer                  |           | not null | nextval('"Users_id_seq"'::regclass)
 email            | character varying(255)   |           | not null |
 password         | character varying(255)   |           | not null |
 role             | integer                  |           | not null | 0
 createdAt        | timestamp with time zone |           | not null |
 updatedAt        | timestamp with time zone |           | not null |
 networkIDs       | json                     |           | not null | '"[]"'::json
 verificationType | integer                  |           | not null | 0
 organization     | character varying(255)   |           | not null | 'fb-test'::character varying
 readOnly         | boolean                  |           | not null | false
 tabs             | json                     |           |          | '[]'::json
Indexes:
    "Users_pkey" PRIMARY KEY, btree (id)
```

<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->
