### PR TITLE
Upgrade sequelize-models version to ^0.1.7

### DIFF
--- a/fbcnms-packages/fbcnms-express-middleware/package.json
+++ b/fbcnms-packages/fbcnms-express-middleware/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@fbcnms/express-middleware",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": {
     "@fbcnms/logging": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.1",
+    "@fbcnms/sequelize-models": "^0.1.7",
     "body-parser": "^1.18.3",
     "compression": "^1.7.1",
     "cookie-parser": "^1.4.3",

--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@fbcnms/platform-server",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "dependencies": {
     "@fbcnms/auth": "^0.1.0",
     "@fbcnms/babel-register": "^0.1.0",
     "@fbcnms/express-middleware": "^0.1.0",
     "@fbcnms/logging": "^0.1.0",
     "@fbcnms/magma-api": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.1",
+    "@fbcnms/sequelize-models": "^0.1.7",
     "@fbcnms/types": "^0.1.10",
     "@fbcnms/util": "^0.1.0",
     "add": "^2.0.6",


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

Upgrade version of `@fbcnms/sequelize-models` to `^0.1.7`

<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->
