### PR TITLE
[fbcnms-alarms] Add getnetworkid param to Alarms

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/components/AlarmContext.js
+++ b/fbcnms-packages/fbcnms-alarms/components/AlarmContext.js
@@ -20,6 +20,7 @@ export type AlarmContext = {|
   filterLabels?: (labels: Labels) => Labels,
   ruleMap: RuleInterfaceMap<*>,
   getAlertType?: ?GetAlertType,
+  getNetworkId?: () => string,
   // feature flags
   thresholdEditorEnabled?: boolean,
   alertManagerGlobalConfigEnabled?: boolean,

--- a/fbcnms-packages/fbcnms-alarms/components/Alarms.js
+++ b/fbcnms-packages/fbcnms-alarms/components/Alarms.js
@@ -8,7 +8,6 @@
  * @format
  */
 
-//$FlowFixMe: flow-typed does not provide definition for this
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import AlarmContext from './AlarmContext';
 import AlertRules from './AlertRules';
@@ -89,6 +88,7 @@ type Props<TRuleUnion> = {
   disabledTabs?: Array<string>,
   // context props
   apiUtil: ApiUtil,
+  getNetworkId?: () => string,
   ruleMap?: ?RuleInterfaceMap<TRuleUnion>,
   thresholdEditorEnabled?: boolean,
   alertManagerGlobalConfigEnabled?: boolean,
@@ -101,6 +101,7 @@ export default function Alarms<TRuleUnion>(props: Props<TRuleUnion>) {
     apiUtil,
     filterLabels,
     makeTabLink,
+    getNetworkId,
     disabledTabs,
     thresholdEditorEnabled,
     alertManagerGlobalConfigEnabled,
@@ -126,6 +127,7 @@ export default function Alarms<TRuleUnion>(props: Props<TRuleUnion>) {
         thresholdEditorEnabled,
         alertManagerGlobalConfigEnabled,
         filterLabels,
+        getNetworkId,
         ruleMap: mergedRuleMap,
         getAlertType: getAlertType,
       }}>

--- a/fbcnms-packages/fbcnms-alarms/components/__tests__/hooks-test.js
+++ b/fbcnms-packages/fbcnms-alarms/components/__tests__/hooks-test.js
@@ -7,15 +7,17 @@
  * @flow
  * @format
  */
-
+import * as React from 'react';
+import {AlarmsTestWrapper, alarmTestUtil} from '../../test/testHelpers';
 import {act as hooksAct, renderHook} from '@testing-library/react-hooks';
 import {mockRuleInterface} from '../../test/testData';
-import {useLoadRules} from '../hooks';
+import {useLoadRules, useNetworkId} from '../hooks';
 import type {GenericRule} from '../rules/RuleInterface';
 import type {RenderResult} from '@testing-library/react-hooks';
 
 jest.useFakeTimers();
 
+const {AlarmsWrapper} = alarmTestUtil();
 const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('@fbcnms/ui/hooks/useSnackbar'), 'useEnqueueSnackbar')
@@ -84,6 +86,31 @@ describe('useLoadRules hook', () => {
     expect(prometheusMock).toHaveBeenCalled();
     expect(eventsMock).toHaveBeenCalled();
     expect(result.current.rules).toHaveLength(2);
+  });
+});
+
+describe('useNetworkId hook', () => {
+  it('returns match.params.networkId by default', () => {
+    const {result} = renderHook(() => useNetworkId(), {
+      wrapper: ({children}) => (
+        <AlarmsTestWrapper>
+          <AlarmsWrapper>{children}</AlarmsWrapper>
+        </AlarmsTestWrapper>
+      ),
+    });
+    expect(result.current).toBe('test');
+  });
+  it('returns AlarmsContext.getNetworkId if provided', () => {
+    const {result} = renderHook(() => useNetworkId(), {
+      wrapper: ({children}) => (
+        <AlarmsTestWrapper>
+          <AlarmsWrapper getNetworkId={() => 'getnetworkid-test'}>
+            {children}
+          </AlarmsWrapper>
+        </AlarmsTestWrapper>
+      ),
+    });
+    expect(result.current).toBe('getnetworkid-test');
   });
 });
 

--- a/fbcnms-packages/fbcnms-alarms/components/hooks.js
+++ b/fbcnms-packages/fbcnms-alarms/components/hooks.js
@@ -11,6 +11,7 @@
 import * as React from 'react';
 import axios from 'axios';
 import useRouter from '@fbcnms/ui/hooks/useRouter';
+import {useAlarmContext} from '@fbcnms/alarms/components/AlarmContext';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import type {AlertRoutingTree} from './AlarmAPIType';
 import type {ApiUtil} from './AlarmsApi';
@@ -175,5 +176,9 @@ export function useAlertRuleReceiver({
 
 export function useNetworkId(): string {
   const {match} = useRouter();
+  const {getNetworkId} = useAlarmContext();
+  if (typeof getNetworkId === 'function') {
+    return getNetworkId();
+  }
   return match.params.networkId;
 }

--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -3,7 +3,7 @@
   "description": "UI components for alert configuration of prometheus and alertmanager.",
   "author": "Facebook Connectivity",
   "license": "BSD-2-Clause",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebookincubator/fbc-js-core.git",

--- a/flow-typed/npm/@material-ui/core_v1.x.x.js
+++ b/flow-typed/npm/@material-ui/core_v1.x.x.js
@@ -2495,9 +2495,6 @@ declare module "@material-ui/core/styles" {
 
   declare module.exports: {
     MuiThemeProvider: $Exports<"@material-ui/core/styles/MuiThemeProvider">,
-    makeStyles: <Props, Stl: Style<Props, string>>(
-      Theme => Stl,
-    ) => StyleHookFn<Props, Stl>,
     withStyles: $Exports<"@material-ui/core/styles/withStyles">,
     withTheme: $Exports<"@material-ui/core/styles/withTheme">,
     createGenerateClassName: $Exports<"@material-ui/core/styles/createGenerateClassName">,
@@ -3957,9 +3954,6 @@ declare module "@material-ui/core/styles/transitions.js" {
 declare module "@material-ui/core/styles/withStyles.js" {
   declare module.exports: $Exports<"@material-ui/core/styles/withStyles">;
 }
-declare module "@material-ui/core/styles/makeStyles.js" {
-  declare module.exports: $Exports<"@material-ui/core/styles/makeStyles">;
-}
 declare module "@material-ui/core/styles/withTheme.js" {
   declare module.exports: $Exports<"@material-ui/core/styles/withTheme">;
 }
@@ -4354,9 +4348,6 @@ declare module "@material-ui/core" {
   >;
   declare export var withStyles: $Exports<
     "@material-ui/core/styles/withStyles"
-  >;
-  declare export var makeStyles: $Exports<
-    "@material-ui/core/styles/makeStyles"
   >;
   declare export var withTheme: $Exports<"@material-ui/core/styles/withTheme">;
   declare export var createMuiTheme: $Exports<

--- a/flow-typed/npm/@material-ui/icons_v4.x.x.js
+++ b/flow-typed/npm/@material-ui/icons_v4.x.x.js
@@ -20,7 +20,7 @@ declare module '@material-ui/core/@@SvgIcon' {
     | 'secondary'
     | 'default';
   declare export type SvgIconProps = SVGElementProps & {
-    classes?: {|
+    classes?: $Shape<{|
       root?: string,
       colorSecondary?: string,
       colorAction?: string,
@@ -30,7 +30,7 @@ declare module '@material-ui/core/@@SvgIcon' {
       fontSizeInherit?: string,
       fontSizeSmall?: string,
       fontSizeLarge?: string,
-    |},
+    |}>,
     color?: PropTypes$Color | 'action' | 'disabled' | 'error',
     fontSize?: 'inherit' | 'default' | 'small' | 'large',
     htmlColor?: string,
@@ -263,6 +263,10 @@ declare module '@material-ui/icons/AccountCircleSharp' {
   declare export default SvgIcon;
 }
 declare module '@material-ui/icons/AccountCircleTwoTone' {
+  import typeof SvgIcon from '@material-ui/core/@@SvgIcon';
+  declare export default SvgIcon;
+}
+declare module '@material-ui/icons/AccountTree' {
   import typeof SvgIcon from '@material-ui/core/@@SvgIcon';
   declare export default SvgIcon;
 }
@@ -21087,6 +21091,9 @@ declare module '@material-ui/icons' {
   declare export {
     default as AccountCircleTwoTone,
   } from '@material-ui/icons/AccountCircleTwoTone';
+  declare export {
+    default as AccountTree,
+  } from '@material-ui/icons/AccountTree';
   declare export { default as AcUnit } from '@material-ui/icons/AcUnit';
   declare export {
     default as AcUnitOutlined,


### PR DESCRIPTION
By default, useNetworkId pulls from match.params. This adds a prop to
customize useNetworkId externally. Eventually we'll make the prop
required.

Summary:

Test Plan:
yarn run test
Reviewers:

Subscribers:

Tasks:

Tags:

<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->
