### PR TITLE
[fbcnms-alarms] Update alert detail pane style

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/components/AlarmContext.js
+++ b/fbcnms-packages/fbcnms-alarms/components/AlarmContext.js
@@ -43,6 +43,7 @@ const emptyApiUtil = {
     isLoading: false,
   }),
   viewFiringAlerts: (..._) => Promise.reject('not implemented'),
+  getTroubleshootingLink: (..._) => Promise.reject('not implemented'),
   viewMatchingAlerts: (..._) => Promise.reject('not implemented'),
   createAlertRule: (..._) => Promise.reject('not implemented'),
   editAlertRule: (..._) => Promise.reject('not implemented'),

--- a/fbcnms-packages/fbcnms-alarms/components/AlarmsApi.js
+++ b/fbcnms-packages/fbcnms-alarms/components/AlarmsApi.js
@@ -25,6 +25,11 @@ export type ApiRequest = {
   cancelToken?: CancelToken,
 };
 
+type TroubleshootingLinkType = {
+  link: string,
+  title: string,
+};
+
 export type ApiUtil = {|
   /**
    * React hook for loading data whenever a component mounts and refreshing in
@@ -40,7 +45,9 @@ export type ApiUtil = {|
 
   //alerts
   viewFiringAlerts: (req: ApiRequest) => Promise<Array<FiringAlarm>>,
-
+  getTroubleshootingLink: (req: {
+    alertName: string,
+  }) => Promise<?TroubleshootingLinkType>,
   //rules
   viewMatchingAlerts: (
     req: {expression: string} & ApiRequest,

--- a/fbcnms-packages/fbcnms-alarms/components/alertmanager/AlertDetails/MetricAlertViewer.js
+++ b/fbcnms-packages/fbcnms-alarms/components/alertmanager/AlertDetails/MetricAlertViewer.js
@@ -10,12 +10,12 @@
  */
 
 import * as React from 'react';
-import DescriptionIcon from '@material-ui/icons/Description';
+import Collapse from '@material-ui/core/Collapse';
 import Grid from '@material-ui/core/Grid';
+import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
-import {Detail, ObjectViewer, Section} from './AlertDetailsPane';
+import {ObjectViewer} from './AlertDetailsPane';
 import {useAlarmContext} from '../../AlarmContext';
-
 import type {AlertViewerProps} from '../../rules/RuleInterface';
 
 export default function MetricAlertViewer({alert}: AlertViewerProps) {
@@ -23,21 +23,30 @@ export default function MetricAlertViewer({alert}: AlertViewerProps) {
   const {labels, annotations} = alert || {};
   const {alertname: _a, severity: _s, ...extraLabels} = labels || {};
   const {description, ...extraAnnotations} = annotations || {};
+  const [showDetails, setShowDetails] = React.useState(false);
   return (
-    <Grid container data-testid="metric-alert-viewer" spacing={2}>
-      <Section title={'Details'}>
-        <Detail icon={DescriptionIcon} title="Description">
-          <Typography color="textSecondary">{description}</Typography>
-        </Detail>
-      </Section>
-      <Section title={'Labels'}>
+    <Grid container data-testid="metric-alert-viewer" spacing={5}>
+      <Grid item>
+        <Typography variant="body1">{description}</Typography>
+      </Grid>
+      <Grid item>
         <ObjectViewer
           object={filterLabels ? filterLabels(extraLabels) : extraLabels}
         />
-      </Section>
-      <Section title={'Annotations'} divider={false}>
-        <ObjectViewer object={extraAnnotations} />
-      </Section>
+      </Grid>
+      <Grid item xs={12}>
+        <Link
+          variant="subtitle1"
+          component="button"
+          onClick={() => setShowDetails(!showDetails)}>
+          {'Show More Details'}
+        </Link>
+      </Grid>
+      <Grid item>
+        <Collapse in={showDetails}>
+          <ObjectViewer object={extraAnnotations} />
+        </Collapse>
+      </Grid>
     </Grid>
   );
 }

--- a/fbcnms-packages/fbcnms-alarms/components/severity/SeverityIndicator.js
+++ b/fbcnms-packages/fbcnms-alarms/components/severity/SeverityIndicator.js
@@ -8,6 +8,7 @@
  * @format
  */
 import * as React from 'react';
+import Chip from '@material-ui/core/Chip';
 import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
 import {SEVERITY} from './Severity';
@@ -20,6 +21,13 @@ const useStyles = makeStyles(theme => ({
     height: '10px',
     width: '10px',
     borderRadius: '50%',
+  },
+  chip: {
+    color: 'white',
+    textTransform: 'capitalize',
+    padding: '5px',
+    fontWeight: 600,
+    marginBottom: '20px',
   },
   text: {
     marginLeft: theme.spacing(1),
@@ -50,9 +58,12 @@ const useStyles = makeStyles(theme => ({
 
 type Props = {
   severity: string,
+  // display a chip instead of a circle
+  chip?: boolean,
 };
 
-export default function SeverityIndicator({severity}: Props) {
+export default function SeverityIndicator(props: Props) {
+  const severity = props.severity;
   const value =
     severity && severity.trim() !== '' ? severity.toLowerCase() : 'unknown';
   const classes = useStyles();
@@ -62,10 +73,21 @@ export default function SeverityIndicator({severity}: Props) {
     [value, classes],
   );
 
+  const colorChipClassname = React.useMemo(
+    () => classnames(classes.chip, classes[value] ?? classes.unknown),
+    [value, classes],
+  );
+  const chip = props.chip ?? false;
   return (
-    <Typography noWrap>
-      <span className={colorClassname} />
-      <span className={classes.text}>{value}</span>
-    </Typography>
+    <>
+      {!chip ? (
+        <Typography noWrap>
+          <span className={colorClassname} />
+          <span className={classes.text}>{value}</span>
+        </Typography>
+      ) : (
+        <Chip label={value} className={colorChipClassname} />
+      )}
+    </>
   );
 }

--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -3,7 +3,7 @@
   "description": "UI components for alert configuration of prometheus and alertmanager.",
   "author": "Facebook Connectivity",
   "license": "BSD-2-Clause",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebookincubator/fbc-js-core.git",

--- a/fbcnms-packages/fbcnms-alarms/test/testHelpers.js
+++ b/fbcnms-packages/fbcnms-alarms/test/testHelpers.js
@@ -47,6 +47,7 @@ export function mockApiUtil(merge?: $Shape<ApiUtil>): ApiUtil {
       useAlarmsApi: useMagmaAPIMock,
       viewFiringAlerts: jest.fn(),
       viewMatchingAlerts: jest.fn(),
+      getTroubleshootingLink: jest.fn(),
       createAlertRule: jest.fn(),
       editAlertRule: jest.fn(),
       getAlertRules: jest.fn(),

--- a/fbcnms-packages/fbcnms-ui/insights/Alarms/AlarmApi.js
+++ b/fbcnms-packages/fbcnms-ui/insights/Alarms/AlarmApi.js
@@ -29,6 +29,11 @@ export const MagmaAlarmsApiUtil: ApiUtil = {
     });
     return alerts;
   },
+  getTroubleshootingLink: async ({alertName: _}) =>
+    Promise.resolve({
+      link: '',
+      title: 'View Troubleshooting Documentation',
+    }),
   viewMatchingAlerts: async ({networkId: _, expression: __}) => {
     console.warn('not implemented');
     return [];


### PR DESCRIPTION
Updated alert detail pane style
Added Chip view option to severity indicator component 

Before : 
<img width="446" alt="Capture d’écran 2021-06-18 à 21 15 16" src="https://user-images.githubusercontent.com/26038920/122607187-7d32c980-d07a-11eb-8c45-f315d316c6aa.png">



After: 
<img width="446" alt="Capture d’écran 2021-06-18 à 21 17 42" src="https://user-images.githubusercontent.com/26038920/122607307-a7848700-d07a-11eb-9425-eb0f91f9746c.png">


Test Plan:
yarn run test