### PR TITLE
fix: [sequelize-models] Fix id sequence for tables in Postgres post-db-migration

### DIFF
--- a/fbcnms-packages/fbcnms-express-middleware/package.json
+++ b/fbcnms-packages/fbcnms-express-middleware/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@fbcnms/express-middleware",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "dependencies": {
     "@fbcnms/logging": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.8",
+    "@fbcnms/sequelize-models": "^0.1.9",
     "body-parser": "^1.18.3",
     "compression": "^1.7.1",
     "cookie-parser": "^1.4.3",

--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@fbcnms/platform-server",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "dependencies": {
     "@fbcnms/auth": "^0.1.0",
     "@fbcnms/babel-register": "^0.1.0",
     "@fbcnms/express-middleware": "^0.1.0",
     "@fbcnms/logging": "^0.1.0",
     "@fbcnms/magma-api": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.8",
+    "@fbcnms/sequelize-models": "^0.1.9",
     "@fbcnms/types": "^0.1.10",
     "@fbcnms/util": "^0.1.0",
     "add": "^2.0.6",

--- a/fbcnms-packages/fbcnms-sequelize-models/migrations/20210616000000-pg-set-id-seq.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/migrations/20210616000000-pg-set-id-seq.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {DataTypes, QueryInterface, Transaction} from 'sequelize';
+
+const SequelizeTables = [
+  'AuditLogEntries',
+  'FeatureFlags',
+  'Organizations',
+  'Users',
+];
+
+const SequenceColumn = 'id';
+
+/**
+ * For Postgres, fixes the id sequence for tables that have been migrated.
+ * When migrating table data to Postgres, it is necessary to reset the id
+ * sequence, otherwise inserts will fail due to unique ID constraint.
+ * This resetting of ID sequences was not accounted for in this package's
+ * db data migration function, so this migration can account for that.
+ */
+module.exports = {
+  up: (queryInterface: QueryInterface, _types: DataTypes) => {
+    return queryInterface.sequelize.transaction(
+      async (transaction: Transaction): Promise<void> => {
+        try {
+          for (const table of SequelizeTables) {
+            // Get current highest value from the table
+            const [
+              [{max}],
+            ] = await queryInterface.sequelize.query(
+              `SELECT MAX("${SequenceColumn}") AS max FROM "${table}";`,
+              {transaction},
+            );
+
+            // Set the autoincrement current value to highest value + 1
+            await queryInterface.sequelize.query(
+              `ALTER SEQUENCE "${table}_id_seq" RESTART WITH ${max + 1};`,
+              {transaction},
+            );
+          }
+        } catch (exception) {
+          // This likely means we're just not running in Postgres.
+          // Do nothing.
+          console.error(
+            'Had an issue resetting ID sequences. ',
+            'If you are running Postgres, you may need to reset ID sequences manually. ',
+            'Otherwise, ignore this error',
+            'Exception: ',
+            exception,
+          );
+        }
+      },
+    );
+  },
+
+  down: (_queryInterface: QueryInterface, _types: DataTypes) => {
+    return Promise.resolve();
+  },
+};

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "scripts": {
     "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
   },


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Fix explanation:

Package `@fbcnms/sequelize-models` provides a command to migrate model data between databases. This was mainly used to migrate data from MariaDB to Postgres. This feature did not account for resetting the 'id sequence' for each table. As a result, new rows entered into the new tables would re-use IDs, and inserts would fail.

See here for fix explanation on StackOverflow: [link](https://stackoverflow.com/questions/244243/how-to-reset-postgres-primary-key-sequence-when-it-falls-out-of-sync)

There are two parts to this fix:
1. Sequelize migration
2. Edit to `@fbcnms/sequelize-models` so that for Postgres, 'id sequence' will be reset correctly.

## Test - Sequelize Migration

First, checked that the migration runs correctly.

Before migration:
```
nms=# select * from "Organizations_id_seq";
    sequence_name     | last_value | start_value | increment_by |      max_value      | min_value | cache_value | log_cnt | is_cycled | is_called
----------------------+------------+-------------+--------------+---------------------+-----------+-------------+---------+-----------+-----------
 Organizations_id_seq |          5 |           1 |            1 | 9223372036854775807 |         1 |           1 |       0 | f         | f
(1 row)

nms=# select id from "Organizations";
 id
----
  1
  2
  3
  4
  5
  8
  9
 10
(8 rows)
```

And after running the migration, the table `Organizations_id_seq` is set correctly:
```
nms=# select * from "Organizations_id_seq";
    sequence_name     | last_value | start_value | increment_by |      max_value      | min_value | cache_value | log_cnt | is_cycled | is_called
----------------------+------------+-------------+--------------+---------------------+-----------+-------------+---------+-----------+-----------
 Organizations_id_seq |         11 |           1 |            1 | 9223372036854775807 |         1 |           1 |       0 | f         | f
(1 row)
```

## Test - @fbcnms/sequelize-models dbDataMigration

To test this, a Magma NMS set up was used, with data stored on MariaDB, and the `dbDataMigration` command was used to migrate data to Postgres.

See bash output here:
```
bash-5.0# yarn dbDataMigrate
yarn run v1.22.4
warning package.json: No license field
$ node -r @fbcnms/babel-register dbDataMigration.js
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
? Enter DB host: postgres
? Enter DB port: 5432
? Enter DB database name: nms
? Enter DB username: nms
? Enter DB password: [hidden]
? Enter DB SQL dialect: postgres

DB Connection Config:
---------------------------
Host: postgres:5432
Database: nms
Username: nms
Dialect: postgres

? Are you importing from the specified DB, or exporting to it?: export
? Would you like to run data migration with these settings?: Yes
.
.
... (Executing statements, see relevant statements below)
.
.
.
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): START TRANSACTION;
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): SELECT MAX("id") AS max FROM "AuditLogEntries";
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): ALTER SEQUENCE "AuditLogEntries_id_seq" RESTART WITH 2;
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): SELECT MAX("id") AS max FROM "FeatureFlags";
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): ALTER SEQUENCE "FeatureFlags_id_seq" RESTART WITH 1;
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): SELECT MAX("id") AS max FROM "Organizations";
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): ALTER SEQUENCE "Organizations_id_seq" RESTART WITH 4;
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): SELECT MAX("id") AS max FROM "Users";
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): ALTER SEQUENCE "Users_id_seq" RESTART WITH 16;
Executing (665d95da-18b1-4844-92a1-6f9c16032fe3): COMMIT;
Completed data migration, exported to specified DB

Done in 47.85s.
bash-5.0#
```

