### PR TITLE
fix: [sequelize-models] Migrate all organizations to be lower case

### DIFF
--- a/fbcnms-packages/fbcnms-sequelize-models/README.md
+++ b/fbcnms-packages/fbcnms-sequelize-models/README.md
@@ -1,6 +1,34 @@
 # fbcnms-sequelize-models
 
-## dbDataMigration Usage
+Package `@fbcnms/sequelize-models` uses the [Sequelize ORM](https://sequelize.org/)
+and defines various models commonly used in different NMS products.
+
+As of last update, this package is used by various Facebook Connectivity products,
+and also [Magma](https://www.magmacore.org/).
+
+## Models
+
+**Organization**
+
+Access control to NMS products are separated based on organizations.
+
+For example, in Magma, organizations can be assigned access to one or more
+networks.
+
+**User**
+
+Users exist per-organization, and additional access control can be set for
+individual users.
+
+**Audit Log Entry**
+
+A log of all actions taken by users on the NMS.
+
+**Feature Flag**
+
+## Yarn Commands
+
+### dbDataMigration Usage
 
 Used for migration of sequelize-models data from one DB to another
 

--- a/fbcnms-packages/fbcnms-sequelize-models/migrations/20210621000000-orgs-name-lowercase.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/migrations/20210621000000-orgs-name-lowercase.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {DataTypes, QueryInterface, Transaction} from 'sequelize';
+
+// Key: table name
+// Value: column name which denotes the organization name
+const TableOrgNameColumn: {[string]: string} = {
+  AuditLogEntries: 'organization',
+  FeatureFlags: 'organization',
+  Organizations: 'name',
+  Users: 'organization',
+};
+
+/**
+ * This migration changes all organization names to be lower case.
+ * There are various ways in which Sequelize requires some customization
+ * to integrate well with the idiosyncrasies of Postgres.
+ *
+ * One way to simplify this is to change string fields to be lower-case,
+ * as in organization names, which is done here.
+ *
+ * This migration has two sets of nearly identical queries, one for
+ * Postgres, and one for MySQL.
+ */
+module.exports = {
+  up: (queryInterface: QueryInterface, _types: DataTypes) => {
+    return queryInterface.sequelize.transaction(
+      async (transaction: Transaction): Promise<void> => {
+        // Postgres needs capitalized table names surrounded by quotations
+        // This would cause an error in MySQL
+        const dialect = queryInterface.sequelize.getDialect();
+        let quote = '';
+        switch (dialect) {
+          case 'mysql':
+          case 'mariadb':
+            break;
+          case 'postgres':
+            quote = '"';
+            break;
+          default:
+            console.error(
+              `Unsupported DB dialect for migration: ${dialect}` +
+                'Supported dialects are [mysql, mariadb, postgres]',
+            );
+        }
+
+        // Check there won't be any duplicate organizations
+        let query = '';
+        let uniqueCount = 0;
+        let totalCount = 0;
+        try {
+          query = `SELECT COUNT(DISTINCT LOWER(name)) FROM ${quote}Organizations${quote};`;
+          let [results, _metadata] = await queryInterface.sequelize.query(
+            query,
+            {transaction},
+          );
+          uniqueCount = results[0].count;
+          query = `SELECT COUNT(name) FROM ${quote}Organizations${quote};`;
+          [results, _metadata] = await queryInterface.sequelize.query(query, {
+            transaction,
+          });
+          totalCount = results[0].count;
+        } catch (err) {
+          console.error(
+            `Failed to run query for migration: ${query}, error: ${err}`,
+          );
+        }
+        if (uniqueCount < totalCount) {
+          console.error(
+            `There are ${totalCount} organizations and ${uniqueCount} unique organization names. ` +
+              'Make sure there are no matching organization names before trying migration again.',
+          );
+          throw 'Failed to complete migration';
+        }
+
+        // Update organizations to lower-case
+        try {
+          for (const tableName: string of Object.keys(TableOrgNameColumn)) {
+            const orgColName: string = TableOrgNameColumn[tableName];
+            query = `UPDATE ${quote}${tableName}${quote} SET ${orgColName}=lower(${orgColName})`;
+            await queryInterface.sequelize.query(query, {transaction});
+          }
+          return;
+        } catch (err) {
+          console.error(
+            `Failed to run query for migration: ${query}, error: ${err}`,
+          );
+          throw 'Failed to complete migration';
+        }
+      },
+    );
+  },
+
+  down: (_queryInterface: QueryInterface, _types: DataTypes) => {
+    return Promise.resolve();
+  },
+};

--- a/fbcnms-packages/fbcnms-sequelize-models/models/organization.js
+++ b/fbcnms-packages/fbcnms-sequelize-models/models/organization.js
@@ -135,6 +135,10 @@ export default (
       },
     },
   );
+  Organization.addHook('beforeCreate', 'nameToLowerCase', organization => {
+    organization.name = organization.name.toLowerCase();
+    return organization;
+  });
   Organization.associate = function (_models) {
     // associations can be defined here
   };

--- a/fbcnms-packages/fbcnms-sequelize-models/package.json
+++ b/fbcnms-packages/fbcnms-sequelize-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/sequelize-models",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "scripts": {
     "dbDataMigrate": "node -r @fbcnms/babel-register dbDataMigration.js"
   },


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Fix explanation:

Library `@fbcnms/sequelize-models` has some issues when used with Postgres. To mitigate these issues, stemming from `Sequelize` not handling all the idiosyncrasies of Postgres easily, we are opting to migrate certain strings to be lower case only, such as organization names.

There are two parts to this fix:
1. Sequelize migration to migrate all existing organization names to lower case
2. `Organization` sequelize model will get a creation hook to enforce all newly created organizations have lower case names

## Test - Organization Creation

Tested creating an organization on the NMS with capital letters, and verified that the created organization only had lower case letters

## Test - MariaDB Sequelize Migration

First, creating some organizations with upper case names
```
MariaDB [nms]> select id, name from Organizations;
+----+------------+
| id | name       |
+----+------------+
|  2 | fb-test    |
|  3 | magma-test |
|  1 | master     |
|  5 | Test Org 2 |
|  4 | Test Org1  |
|  6 | Test_Org_3 |
+----+------------+
6 rows in set (0.000 sec)
```

Logs from running migration:
```
bash-5.0# yarn migrate
yarn run v1.22.4
$ node -r @fbcnms/babel-register scripts/migrate.js
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
2021-06-22T00:42:42.754Z [scripts/runMigrations.js] info: == 20210621000004-orgs-name-lowercase: migrating =======
Failed to run Postgres query for migration. If you are not running Postgres, this warning can safely be ignored.
Attempting to run MySQL query for migration.
Postgres results:  OkPacket { affectedRows: 0, insertId: 0, warningStatus: 0 }
Postgres results:  OkPacket { affectedRows: 0, insertId: 0, warningStatus: 0 }
Postgres results:  OkPacket { affectedRows: 2, insertId: 0, warningStatus: 0 }
Postgres results:  OkPacket { affectedRows: 2, insertId: 0, warningStatus: 0 }
2021-06-22T00:42:42.870Z [scripts/runMigrations.js] info: == 20210621000004-orgs-name-lowercase: migrated (0.116s)

Ran migrations successfully
Done in 12.52s.
bash-5.0#
```

Verified data in tables:
```
MariaDB [nms]> select id, name from Organizations;
+----+------------+
| id | name       |
+----+------------+
|  2 | fb-test    |
|  3 | magma-test |
|  1 | master     |
|  5 | test org 2 |
|  4 | test org1  |
|  6 | test_org_3 |
+----+------------+
6 rows in set (0.000 sec)
```

## Test - Postgres Sequelize Migration

First, created some organizations and users with upper case organization names:
```
nms=# select id, organization from "Users";
 id | organization
----+--------------
 13 | magma-test
 14 | master
 15 | master
 16 | Test Org 1
 17 | Test Org 2
(5 rows)

nms=# select id, name from "Organizations";
 id |    name
----+------------
  1 | master
  2 | fb-test
  3 | magma-test
  4 | Test Org 1
  5 | Test Org 2
(5 rows)
```

Ran the migration:
```
bash-5.0# yarn migrate
yarn run v1.22.4
$ node -r @fbcnms/babel-register scripts/migrate.js
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
2021-06-22T01:07:35.815Z [scripts/runMigrations.js] info: == 20210621000000-orgs-name-lowercase: migrating =======
Migration results for AuditLogEntries:  []
Migration results for FeatureFlags:  []
Migration results for Organizations:  []
Migration results for Users:  []
2021-06-22T01:07:35.892Z [scripts/runMigrations.js] info: == 20210621000000-orgs-name-lowercase: migrated (0.076s)

Ran migrations successfully
Done in 12.49s.
bash-5.0#
```

Verified data in tables:
```
nms=# select id, organization from "Users";
 id | organization
----+--------------
 13 | magma-test
 14 | master
 15 | master
 16 | test org 1
 17 | test org 2
(5 rows)

nms=# select id, name from "Organizations";
 id |    name
----+------------
  1 | master
  2 | fb-test
  3 | magma-test
  4 | test org 1
  5 | test org 2
(5 rows)
```

## Test - Migration With Duplicate Org Names

With duplicate organization names, we prefer to log and throw an error to let the user manage their organizations before the migration.
```
bash-5.0# yarn migrate
yarn run v1.22.4
$ node -r @fbcnms/babel-register scripts/migrate.js
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
2021-06-22T22:16:07.387Z [scripts/runMigrations.js] info: == 20210621000000-orgs-name-lowercase: migrating =======
dialect: <postgres>
There are 8 organizations and 7 unique organization names.Make sure there are no matching organization names before trying migration again.
Failed to run migrations
Done in 12.54s.
bash-5.0#
```