### PR TITLE
chore(alarms): Upgrade version of fbcnms-ui to 0.2.0

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -3,7 +3,7 @@
   "description": "UI components for alert configuration of prometheus and alertmanager.",
   "author": "Facebook Connectivity",
   "license": "BSD-2-Clause",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebookincubator/fbc-js-core.git",
@@ -21,7 +21,7 @@
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.30",
     "@material-ui/styles": "^4.0.0",
-    "@fbcnms/ui":"0.1.11",
+    "@fbcnms/ui":"0.2.0",
     "axios": "^0.21.1",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,32 +1553,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@fbcnms/ui@0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@fbcnms/ui/-/ui-0.1.11.tgz#a04610328f2b15a1313cb5d9b4d20306439c3bdc"
-  integrity sha512-V6AT6lq7f1kP4ezroo26gfOdQqv0oYFjYgVAP4NovKwy8pa5gZcEhg4tWl61oDy4odiUa0meuRIPMBjk4hvXlQ==
-  dependencies:
-    "@material-ui/core" "^4.0.0"
-    "@material-ui/icons" "^4.0.0"
-    "@material-ui/lab" "^4.0.0-alpha.30"
-    "@material-ui/styles" "^4.0.0"
-    "@storybook/addon-actions" "^5.3.19"
-    beaver-logger "^4.0.12"
-    immutable "^4.0.0-rc.12"
-    mapbox-gl "^0.53.0"
-    notistack "^1.0.3"
-    react "^16.8.6"
-    react-autosuggest "^9.4.3"
-    react-chartjs-2 "^2.7.4"
-    react-dom "^16.8.6"
-    react-draggable "^4.4.3"
-    react-perfect-scrollbar "^1.4.4"
-    react-router "5.1.2"
-    react-router-dom "5.1.2"
-    react-test-renderer "^16.12.0"
-    react-virtualized "^9.21.0"
-    relay-runtime "0.0.0-master-86f5456a"
-
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

This PR updates `@fbcnms/alarms` to `0.3.1`, upgrading its dependency `@fbcnms/ui` to `0.2.0`

This is part of a series of PRs to remove any Magma-dependent code from fbc-js-core, so that all packages will be more easily reusable between FBC-derived projects, including Magma.

## Tests
Sanity test from running unit tests:
```
➜  fbc-js-core git:(platform-rm-magma) yarn run test
```
