### PR TITLE
feat(fbcnms-ui): Add Organization create

### DIFF
--- a/fbcnms-packages/fbcnms-ui/components/auth/EditUserDialog.js
+++ b/fbcnms-packages/fbcnms-ui/components/auth/EditUserDialog.js
@@ -37,7 +37,7 @@ export type EditUser = {
   organization?: string,
 };
 
-type SaveUserData = {
+export type SaveUserData = {
   email: string,
   password?: string,
   role: number,

--- a/fbcnms-packages/fbcnms-ui/components/design-system/Button.js
+++ b/fbcnms-packages/fbcnms-ui/components/design-system/Button.js
@@ -15,6 +15,7 @@ import * as React from 'react';
 import Text from './Text';
 import classNames from 'classnames';
 import symphony from '../../theme/symphony';
+import {comet} from '../../theme/colors';
 import {joinNullableStrings} from '@fbcnms/util/strings';
 import {makeStyles} from '@material-ui/styles';
 import {useFormElementContext} from './Form/FormElementContext';
@@ -66,8 +67,10 @@ const useStyles = makeStyles(_theme => ({
   regularSkin: {},
   graySkin: {},
   secondaryGraySkin: {},
+  cometSkin: {},
   disabled: {},
   containedVariant: {
+    color: 'white',
     height: '32px',
     minWidth: '88px',
     padding: '4px 12px',
@@ -77,6 +80,27 @@ const useStyles = makeStyles(_theme => ({
     },
     '&$hasLeftIcon': {
       padding: '4px 12px 4px 6px',
+    },
+    '&$cometSkin': {
+      backgroundColor: comet,
+      '&:not($disabled)': {
+        '& $buttonText, $icon': {
+          color: symphony.palette.white,
+          fill: symphony.palette.white,
+        },
+      },
+      '&:hover:not($disabled)': {
+        '& $buttonText, $icon': {
+          color: symphony.palette.white,
+          fill: symphony.palette.white,
+        },
+      },
+      '&:active:not($disabled)': {
+        '& $buttonText, $icon': {
+          color: symphony.palette.B700,
+          fill: symphony.palette.B700,
+        },
+      },
     },
     '&$primarySkin': {
       backgroundColor: symphony.palette.primary,
@@ -130,7 +154,7 @@ const useStyles = makeStyles(_theme => ({
       },
       '&:hover:not($disabled)': {
         '& $buttonText, $icon': {
-          color: symphony.palette.primary,
+          color: comet,
           fill: symphony.palette.primary,
         },
       },
@@ -298,6 +322,26 @@ const useStyles = makeStyles(_theme => ({
         },
       },
     },
+    '&$cometSkin': {
+      '&:not($disabled)': {
+        '& $buttonText, $icon': {
+          color: symphony.palette.D500,
+          fill: symphony.palette.D500,
+        },
+      },
+      '&:hover:not($disabled)': {
+        '& $buttonText, $icon': {
+          color: symphony.palette.D900,
+          fill: symphony.palette.D900,
+        },
+      },
+      '&:active:not($disabled)': {
+        '& $buttonText, $icon': {
+          color: symphony.palette.primary,
+          fill: symphony.palette.primary,
+        },
+      },
+    },
     '&$disabled': {
       cursor: 'default',
       '& $buttonText, $icon': {
@@ -316,7 +360,8 @@ export type ButtonSkin =
   | 'gray'
   | 'secondaryGray'
   | 'orange'
-  | 'green';
+  | 'green'
+  | 'comet';
 
 export type ButtonProps = $ReadOnly<{|
   skin?: ButtonSkin,

--- a/fbcnms-packages/fbcnms-ui/components/design-system/FormField/FormField.js
+++ b/fbcnms-packages/fbcnms-ui/components/design-system/FormField/FormField.js
@@ -11,10 +11,15 @@
 import * as React from 'react';
 import FormAlertsContext from '../Form/FormAlertsContext';
 import FormElementContext from '../Form/FormElementContext';
+import Grid from '@material-ui/core/Grid';
+import ListItem from '@material-ui/core/ListItem';
 import Text from '../Text';
+import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
+import grey from '@material-ui/core/colors/grey';
 import nullthrows from 'nullthrows';
 import symphony from '@fbcnms/ui/theme/symphony';
+
 import {makeStyles} from '@material-ui/styles';
 import {useContext, useMemo} from 'react';
 
@@ -43,6 +48,21 @@ const useStyles = makeStyles(() => ({
   spacer: {
     marginTop: '4px',
     height: '16px',
+  },
+  subheading: {
+    fontWeight: '400',
+  },
+  optionalLabel: {
+    color: grey.A700,
+    fontStyle: 'italic',
+    fontWeight: '400',
+    marginLeft: '8px',
+  },
+  label: {
+    fontSize: '16px',
+  },
+  children: {
+    padding: '8px 0',
   },
 }));
 
@@ -141,3 +161,48 @@ FormField.defaultProps = {
 };
 
 export default FormField;
+
+type AltFormFieldProps = {
+  label: string,
+  children?: any,
+  dense?: boolean,
+  tooltip?: string,
+  subLabel?: string,
+  isOptional?: boolean,
+  disableGutters?: boolean,
+};
+
+export function AltFormField(props: AltFormFieldProps) {
+  const classes = useStyles();
+  return (
+    <ListItem dense={props.dense} disableGutters={props.disableGutters}>
+      <Grid container>
+        <Grid item xs={12} className={classes.label}>
+          {props.label}
+          {props.isOptional && (
+            <Typography
+              className={classes.optionalLabel}
+              variant="caption"
+              gutterBottom>
+              {'optional'}
+            </Typography>
+          )}
+        </Grid>
+        {props.subLabel && (
+          <Grid item xs={12}>
+            <Typography
+              className={classes.subheading}
+              variant="caption"
+              display="block"
+              gutterBottom>
+              {props.subLabel}
+            </Typography>
+          </Grid>
+        )}
+        <Grid item xs={12} className={classes.children}>
+          {props.children}
+        </Grid>
+      </Grid>
+    </ListItem>
+  );
+}

--- a/fbcnms-packages/fbcnms-ui/components/design-system/FormField/FormField.js
+++ b/fbcnms-packages/fbcnms-ui/components/design-system/FormField/FormField.js
@@ -163,12 +163,19 @@ FormField.defaultProps = {
 export default FormField;
 
 type AltFormFieldProps = {
+  // Label of the form field
   label: string,
+  // Content of the component (Eg, Input, OutlinedInpir, Switch)
   children?: any,
+  // If true, compact vertical padding designed for keyboard and mouse input is used
   dense?: boolean,
+  // Tooltio of the field
   tooltip?: string,
+  // SubLabel of the form field
   subLabel?: string,
+  // If true, adds a optional caption to the form field
   isOptional?: boolean,
+  // If true, the left and right padding is removed.
   disableGutters?: boolean,
 };
 

--- a/fbcnms-packages/fbcnms-ui/master/OrganizationInfoDialog.js
+++ b/fbcnms-packages/fbcnms-ui/master/OrganizationInfoDialog.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {DialogProps} from './OrganizationDialog';
+
+import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
+import Button from '@fbcnms/ui/components/design-system/Button';
+import Checkbox from '@material-ui/core/Checkbox';
+import Collapse from '@material-ui/core/Collapse';
+import DialogContent from '@material-ui/core/DialogContent';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import FormLabel from '@material-ui/core/FormLabel';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import React from 'react';
+import Select from '@material-ui/core/Select';
+
+import {AltFormField} from '@fbcnms/ui/components/design-system/FormField/FormField';
+import {useState} from 'react';
+
+const ENABLE_ALL_NETWORKS_HELPER =
+  'By checking this, the organization will have access to all existing and future networks.';
+
+/**
+ * Create Organization Tab
+ * This component displays a form used to create an organization
+ */
+export default function OrganizationInfoDialog(props: DialogProps) {
+  const {
+    organization,
+    allNetworks,
+    shouldEnableAllNetworks,
+    setShouldEnableAllNetworks,
+  } = props;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DialogContent>
+      <List>
+        {props.error && (
+          <AltFormField label={''}>
+            <FormLabel error>{props.error}</FormLabel>
+          </AltFormField>
+        )}
+        <AltFormField disableGutters label={'Organization Name'}>
+          <OutlinedInput
+            data-testid="name"
+            placeholder="Organization Name"
+            fullWidth={true}
+            value={organization.name}
+            onChange={({target}) => {
+              props.onOrganizationChange({...organization, name: target.value});
+            }}
+          />
+        </AltFormField>
+        <ListItem disableGutters>
+          <Button variant="text" onClick={() => setOpen(!open)}>
+            Advanced Settings
+          </Button>
+          <ArrowDropDown />
+        </ListItem>
+        <Collapse in={open}>
+          <AltFormField
+            disableGutters
+            label={'Accessible Networks'}
+            subLabel={'The networks that the organization have access to'}>
+            <Select
+              fullWidth={true}
+              variant={'outlined'}
+              multiple={true}
+              renderValue={selected => selected.join(', ')}
+              value={organization.networkIDs || []}
+              onChange={({target}) => {
+                props.onOrganizationChange({
+                  ...organization,
+                  networkIDs: [...target.value],
+                });
+              }}
+              input={<OutlinedInput id="direction" />}>
+              {allNetworks.map(network => (
+                <MenuItem key={network} value={network}>
+                  <ListItemText primary={network} />
+                </MenuItem>
+              ))}
+            </Select>
+          </AltFormField>
+          <FormControlLabel
+            disableGutters
+            label={'Give this organization access to all networks'}
+            control={
+              <Checkbox
+                checked={shouldEnableAllNetworks}
+                onChange={() =>
+                  setShouldEnableAllNetworks(!shouldEnableAllNetworks)
+                }
+              />
+            }
+          />
+          <FormHelperText>{ENABLE_ALL_NETWORKS_HELPER}</FormHelperText>
+        </Collapse>
+      </List>
+    </DialogContent>
+  );
+}

--- a/fbcnms-packages/fbcnms-ui/master/OrganizationUserDialog.js
+++ b/fbcnms-packages/fbcnms-ui/master/OrganizationUserDialog.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DialogProps} from './OrganizationDialog';
+
+import DialogContent from '@material-ui/core/DialogContent';
+import FormLabel from '@material-ui/core/FormLabel';
+import List from '@material-ui/core/List';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import React from 'react';
+import Select from '@material-ui/core/Select';
+
+import {AltFormField} from '@fbcnms/ui/components/design-system/FormField/FormField';
+import {UserRoles} from '@fbcnms/auth/types';
+
+/**
+ * Create User Tab
+ * This component displays a form used to create a user that belongs to a new organization
+ */
+export default function OrganizationUserDialog(props: DialogProps) {
+  const {user} = props;
+
+  return (
+    <DialogContent>
+      <List>
+        {props.error && (
+          <AltFormField label={''}>
+            <FormLabel error>{props.error}</FormLabel>
+          </AltFormField>
+        )}
+        <AltFormField disableGutters label={'Email'}>
+          <OutlinedInput
+            data-testid="name"
+            placeholder="Email"
+            fullWidth={true}
+            value={user.email}
+            onChange={({target}) => {
+              props.onUserChange({...user, email: target.value});
+            }}
+          />
+        </AltFormField>
+        <AltFormField disableGutters label={'Password'}>
+          <OutlinedInput
+            data-testid="name"
+            placeholder="Enter Password"
+            fullWidth={true}
+            value={user.password}
+            onChange={({target}) => {
+              props.onUserChange({...user, password: target.value});
+            }}
+          />
+        </AltFormField>
+        <AltFormField disableGutters label={'Confirm Password'}>
+          <OutlinedInput
+            data-testid="name"
+            placeholder="Enter Password Confirmation"
+            fullWidth={true}
+            value={user.passwordConfirmation}
+            onChange={({target}) => {
+              props.onUserChange({...user, passwordConfirmation: target.value});
+            }}
+          />
+        </AltFormField>
+        <AltFormField
+          disableGutters
+          label={'Role'}
+          subLabel={
+            'The role decides permissions that the user has to areas and features '
+          }>
+          <Select
+            fullWidth={true}
+            variant={'outlined'}
+            value={user.role ?? 0}
+            onChange={({target}) => {
+              props.onUserChange({...user, role: target.value});
+            }}
+            input={<OutlinedInput id="direction" />}>
+            <MenuItem key={UserRoles.USER} value={UserRoles.USER}>
+              <ListItemText primary={'User'} />
+            </MenuItem>
+            <MenuItem
+              key={UserRoles.READ_ONLY_USER}
+              value={UserRoles.READ_ONLY_USER}>
+              <ListItemText primary={'Read Only User'} />
+            </MenuItem>
+            <MenuItem key={UserRoles.SUPERUSER} value={UserRoles.SUPERUSER}>
+              <ListItemText primary={'SuperUser'} />
+            </MenuItem>
+          </Select>
+        </AltFormField>
+      </List>
+    </DialogContent>
+  );
+}

--- a/fbcnms-packages/fbcnms-ui/theme/default.js
+++ b/fbcnms-packages/fbcnms-ui/theme/default.js
@@ -14,12 +14,14 @@ import {
   blue30,
   blue60,
   blueGrayDark,
+  brightGray,
   fadedBlue,
   gray0,
   gray00,
   gray1,
   gray13,
   gray50,
+  gullGray,
   primaryText,
   red,
   redwood,
@@ -158,6 +160,10 @@ export default createMuiTheme({
     },
     MuiOutlinedInput: {
       root: {
+        color: brightGray,
+        backgroundColor: white,
+        minHeight: '56px',
+        borderColor: white,
         '&$notchedOutline': {
           borderColor: '#CCD0D5',
         },
@@ -170,7 +176,12 @@ export default createMuiTheme({
         },
       },
       input: {
-        fontSize: '14px',
+        color: gullGray,
+        fontFamily: '"Inter", sans-serif',
+        fontWeight: 600,
+        fontSize: '12px',
+        lineHeight: 1.33,
+        letterSpacing: '0.5px',
         lineHeight: '14px',
         paddingBottom: '12px',
         paddingTop: '12px',
@@ -203,6 +214,11 @@ export default createMuiTheme({
         '&::-ms-input-placeholder': {
           opacity: 1,
         },
+      },
+    },
+    MuiDialogContent: {
+      root: {
+        padding: '0 32px',
       },
     },
   },


### PR DESCRIPTION
Add Organization create dialog.
Updated Dialog, FormField and Button style.

The user can click on Add Organization button to display the add organization dialog. The first tab is used to fill the new organization info and the second tab is used to create a user that belongs to the new organization.



<img width="1792" alt="Capture d’écran 2022-01-27 à 17 23 51" src="https://user-images.githubusercontent.com/26038920/151400907-baea2088-b8df-49b1-a3da-0aacb20476b7.png">


<img width="1792" alt="Capture d’écran 2022-01-27 à 17 23 42" src="https://user-images.githubusercontent.com/26038920/151400909-3b8f3c3e-ee27-4e01-9819-e31f4ddbb026.png">


<img width="1792" alt="Capture d’écran 2022-01-27 à 17 24 33" src="https://user-images.githubusercontent.com/26038920/151400901-48feeee0-f8ea-4267-90b1-2530262a50e6.png">

