### PR TITLE
fix(alarms): remove spaces from label name

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/components/rules/LabelsEditor.js
+++ b/fbcnms-packages/fbcnms-alarms/components/rules/LabelsEditor.js
@@ -68,7 +68,7 @@ export default function LabelsEditor({labels, onChange}: Props) {
 
   const handleKeyChange = React.useCallback(
     (index: number, newKey: string) => {
-      updateLabel(index, newKey, labelsState[index][1]);
+      updateLabel(index, newKey.replace(/\s/g, '_'), labelsState[index][1]);
     },
     [labelsState, updateLabel],
   );

--- a/fbcnms-packages/fbcnms-alarms/components/rules/__tests__/LabelsEditor-test.js
+++ b/fbcnms-packages/fbcnms-alarms/components/rules/__tests__/LabelsEditor-test.js
@@ -65,6 +65,34 @@ test('typing into a key field edits the key of a label', () => {
     'testKey2-edited': 'testVal2',
   });
 });
+
+test('spaces in the key field are replaced by underscores', () => {
+  const {getByDisplayValue} = render(
+    <LabelsEditor
+      {...commonProps}
+      labels={{
+        testKey1: 'testVal1',
+        testKey2: 'testVal2',
+      }}
+    />,
+  );
+
+  act(() => {
+    fireEvent.change(getByDisplayValue('testKey1'), {
+      target: {value: 'testKey1 '},
+    });
+  });
+  act(() => {
+    fireEvent.change(getByDisplayValue('testKey2'), {
+      target: {value: 'testKey2 edited'},
+    });
+  });
+  expect(commonProps.onChange).toHaveBeenCalledWith({
+    testKey1_: 'testVal1',
+    testKey2_edited: 'testVal2',
+  });
+});
+
 test('typing into a value field edits the value of a label', () => {
   const {getByDisplayValue} = render(
     <LabelsEditor

--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -11,7 +11,7 @@
   },
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel ./ -d lib/",
+    "build": "babel ./ -d lib/ --ignore '**/__tests__/*.js'",
     "prepublish": "yarn run build",
     "dev": "yarn run yalc-push && chokidar \"components/**/*.js\" \"hooks/**/*.js\" \"util/**/*.js\" -c \"yarn run yalc-push\"",
     "yalc-push": "yalc push"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/runtime": "^7.3.4"
   },
   "scripts": {
-    "eslint": "eslint --version && ./node_modules/.bin/eslint --ignore-path .eslintignore --",
+    "eslint": "eslint --version && ./node_modules/.bin/eslint --fix --ignore-path .eslintignore --",
     "jest": "echo 'Dont run jest directly, use \"yarn run test\"' && exit 1",
     "test": "NODE_ENV=test jest",
     "test:ci": "NODE_ENV=test jest -w 1",


### PR DESCRIPTION
Summary:
spaces in the label name cause issues with the config manager

Test Plan:
yarn run test --watch

Reviewers:
andreilee

Subscribers:

Tasks:
T101473711
Tags:

<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->
