### PR TITLE
bug: cannot-resolve-module multiSamlStrategy

### DIFF
--- a/fbcnms-packages/fbcnms-auth/package.json
+++ b/fbcnms-packages/fbcnms-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/auth",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "dependencies": {
     "@fbcnms/sequelize-models": "^0.1.11",
     "@fbcnms/webpack-config": "^0.1.0",

--- a/fbcnms-packages/fbcnms-auth/strategies/OrganizationSamlStrategy.js
+++ b/fbcnms-packages/fbcnms-auth/strategies/OrganizationSamlStrategy.js
@@ -9,7 +9,7 @@
  */
 
 import {AccessRoles} from '../roles';
-import {MultiSamlStrategy} from 'passport-saml';
+import {MultiSamlStrategy} from 'passport-saml'; // compatibility with breaking change in 3.1.0
 import {User} from '@fbcnms/sequelize-models';
 
 import {getUserFromRequest} from '../util';

--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@fbcnms/platform-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "dependencies": {
-    "@fbcnms/auth": "^0.1.5",
+    "@fbcnms/auth": "^0.1.6",
     "@fbcnms/babel-register": "^0.1.0",
     "@fbcnms/express-middleware": "^0.1.5",
     "@fbcnms/logging": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,17 +1298,10 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.7", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
   integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.7":
-  version "7.17.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
-  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
   dependencies:
     regenerator-runtime "^0.13.4"
 


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/fbc-js-core/issues/168

See https://github.com/magma/security/issues/14#issuecomment-1045433441

Tested with `yarn run flow` and `yarn run test`. Four unit tests are failing, but they fail on the main branch as well - there are no new fails.

Signed-off-by: Lucas Gonze <lucas@gonze.com>

<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->
