### PR TITLE
fix(alarms): alertrules actions menu popover positioning

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/components/AlertRules.js
+++ b/fbcnms-packages/fbcnms-alarms/components/AlertRules.js
@@ -120,6 +120,40 @@ export default function AlertRules<TRuleUnion>() {
     setIsViewAlertModalOpen(false);
     setMatchingAlertsCount(null);
   }, [setIsViewAlertModalOpen, setMatchingAlertsCount]);
+  const columns = React.useMemo(
+    () => [
+      {
+        title: 'Name',
+        field: 'name',
+      },
+      {
+        title: 'Severity',
+        field: 'severity',
+        render: currRow => <SeverityIndicator severity={currRow.severity} />,
+      },
+      {
+        title: 'Fire Alert When',
+        field: 'fireAlertWhen',
+        render: currRow => {
+          try {
+            const exp = Parse(currRow.expression);
+            if (exp) {
+              const metricName = exp.lh.selectorName?.toUpperCase() || '';
+              const operator = exp.operator?.toString() || '';
+              const value = exp.rh.value?.toString() || '';
+              return `${metricName} ${operator} ${value} for ${currRow.period}`;
+            }
+          } catch {}
+          return 'error';
+        },
+      },
+      {
+        title: 'Description',
+        field: 'description',
+      },
+    ],
+    [],
+  );
 
   if (isAddEditAlert) {
     return (
@@ -139,39 +173,7 @@ export default function AlertRules<TRuleUnion>() {
     <Grid className={classes.root}>
       <SimpleTable
         onRowClick={row => setSelectedRow(row)}
-        columnStruct={[
-          {
-            title: 'Name',
-            field: 'name',
-          },
-          {
-            title: 'Severity',
-            field: 'severity',
-            render: currRow => (
-              <SeverityIndicator severity={currRow.severity} />
-            ),
-          },
-          {
-            title: 'Fire Alert When',
-            field: 'fireAlertWhen',
-            render: currRow => {
-              try {
-                const exp = Parse(currRow.expression);
-                if (exp) {
-                  const metricName = exp.lh.selectorName?.toUpperCase() || '';
-                  const operator = exp.operator?.toString() || '';
-                  const value = exp.rh.value?.toString() || '';
-                  return `${metricName} ${operator} ${value} for ${currRow.period}`;
-                }
-              } catch {}
-              return 'error';
-            },
-          },
-          {
-            title: 'Description',
-            field: 'description',
-          },
-        ]}
+        columnStruct={columns}
         tableData={rules || []}
         dataTestId="alert-rules"
         menuItems={[

--- a/fbcnms-packages/fbcnms-alarms/components/table/SimpleTable.js
+++ b/fbcnms-packages/fbcnms-alarms/components/table/SimpleTable.js
@@ -212,7 +212,7 @@ export default function SimpleTable<T>(props: ActionTableProps<T>) {
     setAnchorEl(null);
   };
 
-  if (props.menuItems) {
+  if (props.menuItems && anchorEl) {
     // Actions menu
     const menuItems: Array<ActionMenuItems> = props.menuItems;
     actionTableJSX.push(


### PR DESCRIPTION
Summary:
Clicking a row's actions menu on the alert rules page positioned the
popover at the topleft of the screen. The issue is that columns were
recreated after clicking, causing the anchorEl to be destroyed. The
solution was to memoize the column definitions.

Test Plan:
screenshots

Reviewers:
andreilee

<!--
Use the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#specification

<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
-->
