### PR TITLE
[fbcnms-auth] Fix error getting user info

### DIFF
--- a/fbcnms-packages/fbcnms-auth/package.json
+++ b/fbcnms-packages/fbcnms-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/auth",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "dependencies": {
     "@fbcnms/sequelize-models": "^0.1.11",
     "@fbcnms/webpack-config": "^0.1.0",

--- a/fbcnms-packages/fbcnms-auth/strategies/OrganizationOIDCStrategy.js
+++ b/fbcnms-packages/fbcnms-auth/strategies/OrganizationOIDCStrategy.js
@@ -33,7 +33,7 @@ export default function OrganizationOIDCStrategy(config: Config) {
     userInfo: OpenidUserInfoClaims,
     done: (error: Error | void, user?: User) => void,
   ) => {
-    const email = userInfo.email;
+    const email = userInfo.email || userInfo.attributes.email;
     const organization = await req.organization();
     const ssoDefaultNetworkIDs = organization.ssoDefaultNetworkIDs;
     try {
@@ -46,7 +46,7 @@ export default function OrganizationOIDCStrategy(config: Config) {
           email: email.toLowerCase(),
           password: Math.random().toString(36),
           // Hardcoded role for now, should be configurable
-          role: AccessRoles.SUPERUSER,
+          role: AccessRoles.USER,
           ssoDefaultNetworkIDs,
         });
         user = await User.create(createArgs);
@@ -75,6 +75,7 @@ export default function OrganizationOIDCStrategy(config: Config) {
           path: `${config.urlPrefix}/login/oidc/callback`,
           passReqToCallback: true,
           params: {
+            scope: ['openid email'],
             redirect_uri:
               `https://${host}${config.urlPrefix}/login/oidc/callback?to=` +
               encodeURIComponent(redirectTo),

--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -2,7 +2,7 @@
   "name": "@fbcnms/platform-server",
   "version": "0.3.3",
   "dependencies": {
-    "@fbcnms/auth": "^0.1.6",
+    "@fbcnms/auth": "^0.1.7",
     "@fbcnms/babel-register": "^0.1.0",
     "@fbcnms/express-middleware": "^0.1.5",
     "@fbcnms/logging": "^0.1.0",


### PR DESCRIPTION
OrganizationOIDCStrategy was modified to get user info (email) when token returned by OIDC Provider has the user claims in attributes. Also OIDC scopes (openid, email) were added to DinamycStrategy params, this is required when OIDC Client doesn't return by default these scopes.

