### PR TITLE
feat(fbcnms-ui): Complete transition from 'master' to 'host'

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -3,7 +3,7 @@
   "description": "UI components for alert configuration of prometheus and alertmanager.",
   "author": "Facebook Connectivity",
   "license": "BSD-2-Clause",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebookincubator/fbc-js-core.git",
@@ -17,7 +17,7 @@
     "yalc-push": "yalc push"
   },
   "dependencies": {
-    "@fbcnms/ui": "^1.2.1",
+    "@fbcnms/ui": "^2.0.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
     "moment": "^2.24.0",

--- a/fbcnms-packages/fbcnms-ui/host/Organizations.js
+++ b/fbcnms-packages/fbcnms-ui/host/Organizations.js
@@ -307,13 +307,13 @@ function Organizations(props: Props) {
               onCreateOrg={org => {
                 let newOrg = null;
                 axios
-                  .post('/master/organization/async', org)
+                  .post('/host/organization/async', org)
                   .then(() => {
                     enqueueSnackbar('Organization added successfully', {
                       variant: 'success',
                     });
                     axios
-                      .get(`/master/organization/async/${org.name}`)
+                      .get(`/host/organization/async/${org.name}`)
                       .then(resp => {
                         newOrg = resp.data.organization;
                         if (newOrg) {
@@ -333,7 +333,7 @@ function Organizations(props: Props) {
               onCreateUser={user => {
                 axios
                   .post(
-                    `/master/organization/async/${
+                    `/host/organization/async/${
                       addingUserFor?.name || ''
                     }/add_user`,
                     user,

--- a/fbcnms-packages/fbcnms-ui/package.json
+++ b/fbcnms-packages/fbcnms-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/ui",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "peerDependencies": {
     "@material-table/core": "^4.3.6",
     "@material-ui/core": "^4.0.0",


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

Updates `@fbcnms/fbcnms-ui` to version `2.0.0` and it now accesses organizations at `/host/organization/..` instead of `/master/organization/..`.
