### PR TITLE
fix(fbcnms-alarms): Fix imports from react-router to react-router-dom

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -3,7 +3,7 @@
   "description": "UI components for alert configuration of prometheus and alertmanager.",
   "author": "Facebook Connectivity",
   "license": "BSD-2-Clause",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebookincubator/fbc-js-core.git",
@@ -17,7 +17,7 @@
     "yalc-push": "yalc push"
   },
   "dependencies": {
-    "@fbcnms/ui": "^2.0.0",
+    "@fbcnms/ui": "^2.0.1",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
     "moment": "^2.24.0",


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

Updates the dependency of `@fbcnms/ui` from `2.0.0` to `2.0.1`. See #174 
