### PR TITLE
fix(fbcnms-alarms): Fix call to matchParam of react-router

### DIFF
--- a/fbcnms-packages/fbcnms-alarms/components/Alarms.js
+++ b/fbcnms-packages/fbcnms-alarms/components/Alarms.js
@@ -113,9 +113,10 @@ export default function Alarms<TRuleUnion>(props: Props<TRuleUnion>) {
   const tabStyles = useTabStyles();
   const {match, location} = useRouter();
 
-  const currentTabMatch = matchPath(location.pathname, {
-    path: `${match.path}/:tabName`,
-  });
+  const currentTabMatch = matchPath(
+    location.pathname,
+    `${match.path}/:tabName`,
+  );
   const mergedRuleMap = useMergedRuleMap<TRuleUnion>({ruleMap, apiUtil});
 
   const disabledTabSet = React.useMemo(() => {

--- a/fbcnms-packages/fbcnms-alarms/package.json
+++ b/fbcnms-packages/fbcnms-alarms/package.json
@@ -3,7 +3,7 @@
   "description": "UI components for alert configuration of prometheus and alertmanager.",
   "author": "Facebook Connectivity",
   "license": "BSD-2-Clause",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebookincubator/fbc-js-core.git",


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

- bumped version of `@fbcnms/alarms` to `1.0.5`
- Fixed call of `matchParam` function imported from `react-router`
