### PR TITLE
fix(express-middleware): Bump version to 0.2.0 for master->host

### DIFF
--- a/fbcnms-packages/fbcnms-express-middleware/package.json
+++ b/fbcnms-packages/fbcnms-express-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fbcnms/express-middleware",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "dependencies": {
     "@fbcnms/logging": "^0.1.0",
     "@fbcnms/sequelize-models": "^0.2.0",

--- a/fbcnms-packages/fbcnms-platform-server/package.json
+++ b/fbcnms-packages/fbcnms-platform-server/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@fbcnms/platform-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "dependencies": {
     "@fbcnms/auth": "^0.2.0",
     "@fbcnms/babel-register": "^0.1.0",
-    "@fbcnms/express-middleware": "^0.1.5",
+    "@fbcnms/express-middleware": "^0.2.0",
     "@fbcnms/logging": "^0.1.0",
     "@fbcnms/sequelize-models": "^0.2.0",
     "@fbcnms/types": "^0.1.10",


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

`@fbcnms/express-middleware` was not resolving to the correct version of `@fbcnms/sequelize-models`
